### PR TITLE
feat(issue-2): implement politician disclosures endpoint

### DIFF
--- a/scripts/check-api-sync.js
+++ b/scripts/check-api-sync.js
@@ -137,16 +137,6 @@ function getEndpointCategory(endpoint) {
   return match ? match[1] : 'unknown'
 }
 
-function formatEndpointName(endpoint) {
-  // Convert /api/politician-portfolios/disclosures -> "politician portfolios disclosures"
-  return endpoint
-    .replace(/^\/api\//, '')
-    .replace(/[/-]/g, ' ')
-    .replace(/\{[^}]+\}/g, '')
-    .replace(/\s+/g, ' ')
-    .trim()
-}
-
 async function createGitHubIssue(missing, extra) {
   const token = process.env.GITHUB_TOKEN
   const repo = process.env.GITHUB_REPOSITORY
@@ -161,7 +151,6 @@ async function createGitHubIssue(missing, extra) {
   // Create an issue for each missing endpoint
   for (const endpoint of missing) {
     const category = getEndpointCategory(endpoint)
-    const name = formatEndpointName(endpoint)
 
     const title = `Implement new endpoint: ${endpoint}`
 
@@ -172,7 +161,7 @@ async function createGitHubIssue(missing, extra) {
     body += `### Category\n\n`
     body += `\`${category}\`\n\n`
     body += `### Action Required\n\n`
-    body += `1. Check the [Unusual Whales API documentation](https://docs.unusualwhales.com) for endpoint details\n`
+    body += `1. Check the [Unusual Whales API documentation](https://api.unusualwhales.com/docs) for endpoint details\n`
     body += `2. Add the endpoint to the appropriate tool file in \`src/tools/\`\n`
     body += `3. Update tests if applicable\n\n`
     body += `---\n*This issue was automatically created by the API sync checker.*`

--- a/src/tools/politicians.ts
+++ b/src/tools/politicians.ts
@@ -8,18 +8,27 @@ Available actions:
 - people: List all politicians
 - portfolio: Get a politician's portfolio (politician_id required)
 - recent_trades: Get recent politician trades
-- holders: Get politicians holding a ticker (ticker required)`,
+- holders: Get politicians holding a ticker (ticker required)
+- disclosures: Get annual disclosure file records (optional: politician_id, latest_only, year)`,
   inputSchema: {
     type: "object" as const,
     properties: {
       action: {
         type: "string",
         description: "The action to perform",
-        enum: ["people", "portfolio", "recent_trades", "holders"],
+        enum: ["people", "portfolio", "recent_trades", "holders", "disclosures"],
       },
       politician_id: {
         type: "string",
-        description: "Politician ID (for portfolio action)",
+        description: "Politician ID (for portfolio or disclosures action)",
+      },
+      latest_only: {
+        type: "boolean",
+        description: "Return only most recent disclosure per politician (for disclosures action)",
+      },
+      year: {
+        type: "number",
+        description: "Filter by disclosure year (for disclosures action)",
       },
       ticker: {
         type: "string",
@@ -49,7 +58,7 @@ Available actions:
  * @returns JSON string with politician portfolio data or error message
  */
 export async function handlePoliticians(args: Record<string, unknown>): Promise<string> {
-  const { action, politician_id, ticker, limit, page } = args
+  const { action, politician_id, ticker, limit, page, latest_only, year } = args
 
   switch (action) {
     case "people":
@@ -68,6 +77,13 @@ export async function handlePoliticians(args: Record<string, unknown>): Promise<
     case "holders":
       if (!ticker) return formatError("ticker is required")
       return formatResponse(await uwFetch(`/api/politician-portfolios/holders/${encodePath(ticker)}`))
+
+    case "disclosures":
+      return formatResponse(await uwFetch("/api/politician-portfolios/disclosures", {
+        politician_id: politician_id as string,
+        latest_only: latest_only as boolean,
+        year: year as number,
+      }))
 
     default:
       return formatError(`Unknown action: ${action}`)


### PR DESCRIPTION
## Summary

- Implements the `/api/politician-portfolios/disclosures` endpoint in the `uw_politicians` tool
- Adds support for `politician_id`, `latest_only`, and `year` query parameters
- Cleans up unused code in the API sync checker script
- Fixes the API documentation URL in auto-generated issue templates

## Test plan

- [ ] Run `npm run build` to verify TypeScript compiles
- [ ] Run `npm run check-api` to verify all 107 endpoints are implemented
- [ ] Test the disclosures action with the MCP server