### PR TITLE
feat(issue-4): add Zod schema validation for all MCP tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist/
 .env.local
 *.log
 .DS_Store
+.mcp.json

--- a/README.md
+++ b/README.md
@@ -75,6 +75,33 @@ npm run start     # Run server
 npm run check-api # Check for API changes
 ```
 
+### Debugging with MCP Inspector
+
+To test and debug the server locally, use the [MCP Inspector](https://github.com/modelcontextprotocol/inspector):
+
+```bash
+npm run build
+UW_API_KEY=your_api_key npx @modelcontextprotocol/inspector node ./dist/index.js
+```
+
+This opens a web UI where you can browse available tools, test them interactively, and inspect request/response payloads.
+
+### Testing with Claude Code
+
+To test your local build with Claude Code directly:
+
+```bash
+npm run build
+claude mcp add unusualwhales-dev -e UW_API_KEY=your_api_key -- node /absolute/path/to/unusual-whales-mcp/dist/index.js
+```
+
+Use a different name (like `unusualwhales-dev`) to avoid conflicts with the published package. After making changes, rebuild and restart Claude Code to pick them up.
+
+```bash
+claude mcp list                      # Check server status
+claude mcp remove unusualwhales-dev  # Remove when done
+```
+
 ## License
 
 MIT

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,16 @@
 {
-  "name": "unusual-whales-mcp",
+  "name": "@erikmaday/unusual-whales-mcp",
   "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "unusual-whales-mcp",
+      "name": "@erikmaday/unusual-whales-mcp",
       "version": "0.1.2",
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.0.0"
+        "@modelcontextprotocol/sdk": "^1.0.0",
+        "zod": "^4.3.5"
       },
       "bin": {
         "unusual-whales-mcp": "dist/index.js"
@@ -25,7 +26,7 @@
         "yaml": "^2.8.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -2583,9 +2584,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.4.tgz",
-      "integrity": "sha512-Zw/uYiiyF6pUT1qmKbZziChgNPRu+ZRneAsMUDU6IwmXdWt5JwcUfy2bvLOCUtz5UniaN/Zx5aFttZYbYc7O/A==",
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.5.tgz",
+      "integrity": "sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
     "prepublishOnly": "npm run lint && npm run build"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.0.0"
+    "@modelcontextprotocol/sdk": "^1.0.0",
+    "zod": "^4.3.5"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.2",

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,70 +7,7 @@ import {
 } from "@modelcontextprotocol/sdk/types.js"
 
 import { formatError } from "./client.js"
-import { stockTool, handleStock } from "./tools/stock.js"
-import { optionsTool, handleOptions } from "./tools/options.js"
-import { marketTool, handleMarket } from "./tools/market.js"
-import { flowTool, handleFlow } from "./tools/flow.js"
-import { darkpoolTool, handleDarkpool } from "./tools/darkpool.js"
-import { congressTool, handleCongress } from "./tools/congress.js"
-import { insiderTool, handleInsider } from "./tools/insider.js"
-import { institutionsTool, handleInstitutions } from "./tools/institutions.js"
-import { earningsTool, handleEarnings } from "./tools/earnings.js"
-import { etfTool, handleEtf } from "./tools/etf.js"
-import { screenerTool, handleScreener } from "./tools/screener.js"
-import { shortsTool, handleShorts } from "./tools/shorts.js"
-import { seasonalityTool, handleSeasonality } from "./tools/seasonality.js"
-import { newsTool, handleNews } from "./tools/news.js"
-import { alertsTool, handleAlerts } from "./tools/alerts.js"
-import { politiciansTool, handlePoliticians } from "./tools/politicians.js"
-
-type ToolHandler = (args: Record<string, unknown>) => Promise<string>
-
-interface ToolDefinition {
-  name: string
-  description: string
-  inputSchema: {
-    type: "object"
-    properties: Record<string, unknown>
-    required: string[]
-  }
-  annotations?: {
-    title?: string
-    readOnlyHint?: boolean
-    destructiveHint?: boolean
-    idempotentHint?: boolean
-    openWorldHint?: boolean
-  }
-}
-
-interface ToolRegistration {
-  tool: ToolDefinition
-  handler: ToolHandler
-}
-
-const toolRegistrations: ToolRegistration[] = [
-  { tool: stockTool, handler: handleStock },
-  { tool: optionsTool, handler: handleOptions },
-  { tool: marketTool, handler: handleMarket },
-  { tool: flowTool, handler: handleFlow },
-  { tool: darkpoolTool, handler: handleDarkpool },
-  { tool: congressTool, handler: handleCongress },
-  { tool: insiderTool, handler: handleInsider },
-  { tool: institutionsTool, handler: handleInstitutions },
-  { tool: earningsTool, handler: handleEarnings },
-  { tool: etfTool, handler: handleEtf },
-  { tool: screenerTool, handler: handleScreener },
-  { tool: shortsTool, handler: handleShorts },
-  { tool: seasonalityTool, handler: handleSeasonality },
-  { tool: newsTool, handler: handleNews },
-  { tool: alertsTool, handler: handleAlerts },
-  { tool: politiciansTool, handler: handlePoliticians },
-]
-
-const tools = toolRegistrations.map((reg) => reg.tool)
-const handlers: Record<string, ToolHandler> = Object.fromEntries(
-  toolRegistrations.map((reg) => [reg.tool.name, reg.handler]),
-)
+import { tools, handlers } from "./tools/index.js"
 
 const SERVER_NAME = "unusual-whales"
 const SERVER_VERSION = "1.0.0"

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -1,0 +1,131 @@
+import { z } from "zod"
+
+/**
+ * Convert a Zod schema to JSON Schema format for MCP tool definitions.
+ * Uses Zod v4's native toJSONSchema method.
+ * Strips the $schema property and ensures proper typing.
+ */
+export function toJsonSchema<T extends z.core.$ZodType>(schema: T): {
+  type: "object"
+  properties: Record<string, unknown>
+  required: string[]
+} {
+  const jsonSchema = z.toJSONSchema(schema)
+  // Remove $schema property and return with proper typing
+  const { $schema: _, ...rest } = jsonSchema as Record<string, unknown>
+  return rest as {
+    type: "object"
+    properties: Record<string, unknown>
+    required: string[]
+  }
+}
+
+/**
+ * Format Zod validation errors into a readable string.
+ */
+export function formatZodError<T>(error: z.ZodError<T>): string {
+  return error.issues.map((issue) => issue.message).join(", ")
+}
+
+// ============================================================================
+// Shared field schemas - reusable across tools
+// ============================================================================
+
+/** Date regex pattern for YYYY-MM-DD format */
+const dateRegex = /^\d{4}-\d{2}-\d{2}$/
+
+/** Stock ticker symbol (e.g., AAPL, MSFT, TSLA) */
+export const tickerSchema = z.string()
+  .min(1, "Ticker symbol is required")
+  .max(10, "Ticker symbol too long")
+  .describe("Stock ticker symbol (e.g., AAPL, MSFT)")
+
+/** Date in YYYY-MM-DD format */
+export const dateSchema = z.string()
+  .regex(dateRegex, "Date must be in YYYY-MM-DD format")
+  .describe("Date in YYYY-MM-DD format")
+
+/** Option expiry date in YYYY-MM-DD format */
+export const expirySchema = z.string()
+  .regex(dateRegex, "Expiry date must be in YYYY-MM-DD format")
+  .describe("Option expiry date in YYYY-MM-DD format")
+
+/** Maximum number of results */
+export const limitSchema = z.number()
+  .int("Limit must be an integer")
+  .positive("Limit must be positive")
+  .describe("Maximum number of results")
+
+/** Option strike price */
+export const strikeSchema = z.number()
+  .positive("Strike price must be positive")
+  .describe("Option strike price")
+
+/** Option type (call or put) */
+export const optionTypeSchema = z.enum(["call", "put"]).describe("Option type (call or put)")
+
+/** Order direction */
+export const orderSchema = z.enum(["asc", "desc"]).describe("Order direction")
+
+// ============================================================================
+// Premium/Size/Volume filter schemas - for flow and darkpool tools
+// ============================================================================
+
+export const premiumFilterSchema = z.object({
+  min_premium: z.number().nonnegative("Premium cannot be negative").describe("Minimum premium filter").optional(),
+  max_premium: z.number().nonnegative("Premium cannot be negative").describe("Maximum premium filter").optional(),
+})
+
+export const sizeFilterSchema = z.object({
+  min_size: z.number().int().nonnegative("Size cannot be negative").describe("Minimum size/volume filter").optional(),
+  max_size: z.number().int().nonnegative("Size cannot be negative").describe("Maximum size/volume filter").optional(),
+})
+
+export const volumeFilterSchema = z.object({
+  min_volume: z.number().int().nonnegative("Volume cannot be negative").describe("Minimum volume filter").optional(),
+  max_volume: z.number().int().nonnegative("Volume cannot be negative").describe("Maximum volume filter").optional(),
+})
+
+export const oiFilterSchema = z.object({
+  min_oi: z.number().int().nonnegative("Open interest cannot be negative").describe("Minimum open interest filter").optional(),
+  max_oi: z.number().int().nonnegative("Open interest cannot be negative").describe("Maximum open interest filter").optional(),
+})
+
+export const dteFilterSchema = z.object({
+  min_dte: z.number().int().nonnegative("DTE cannot be negative").describe("Minimum days to expiration").optional(),
+  max_dte: z.number().int().nonnegative("DTE cannot be negative").describe("Maximum days to expiration").optional(),
+})
+
+// ============================================================================
+// Flow-specific schemas
+// ============================================================================
+
+export const flowTradeFiltersSchema = z.object({
+  is_floor: z.boolean().describe("Filter for floor trades").optional(),
+  is_sweep: z.boolean().describe("Filter for sweep trades").optional(),
+  is_multi_leg: z.boolean().describe("Filter for multi-leg trades").optional(),
+  is_unusual: z.boolean().describe("Filter for unusual trades").optional(),
+  is_golden_sweep: z.boolean().describe("Filter for golden sweep trades").optional(),
+})
+
+export const flowGroupSchema = z.enum([
+  "airline", "bank", "basic materials", "china", "communication services",
+  "consumer cyclical", "consumer defensive", "crypto", "cyber", "energy",
+  "financial services", "gas", "gold", "healthcare", "industrials", "mag7",
+  "oil", "real estate", "refiners", "reit", "semi", "silver", "technology",
+  "uranium", "utilities",
+]).describe("Flow group (e.g., mag7, semi, bank, energy, crypto)")
+
+// ============================================================================
+// Candle size schema
+// ============================================================================
+
+export const candleSizeSchema = z.enum([
+  "1m", "5m", "10m", "15m", "30m", "1h", "4h", "1d",
+]).describe("Candle size (1m, 5m, 10m, 15m, 30m, 1h, 4h, 1d)")
+
+// ============================================================================
+// Timeframe schemas
+// ============================================================================
+
+export const timeframeSchema = z.string().describe("Timeframe for historical data")

--- a/src/tools/congress.ts
+++ b/src/tools/congress.ts
@@ -1,4 +1,17 @@
+import { z } from "zod"
 import { uwFetch, formatResponse, formatError } from "../client.js"
+import { toJsonSchema, tickerSchema, dateSchema, limitSchema, formatZodError } from "../schemas.js"
+
+const congressActions = ["recent_trades", "late_reports", "congress_trader"] as const
+
+const congressInputSchema = z.object({
+  action: z.enum(congressActions).describe("The action to perform"),
+  name: z.string().describe("Congress member name (for congress_trader action)").optional(),
+  ticker: tickerSchema.optional(),
+  date: dateSchema.optional(),
+  limit: limitSchema.describe("Maximum number of results (default 100, max 200)").optional(),
+})
+
 
 export const congressTool = {
   name: "uw_congress",
@@ -8,33 +21,7 @@ Available actions:
 - recent_trades: Get recent trades by congress members
 - late_reports: Get recent late reports by congress members
 - congress_trader: Get trades by a specific congress member (name required)`,
-  inputSchema: {
-    type: "object" as const,
-    properties: {
-      action: {
-        type: "string",
-        description: "The action to perform",
-        enum: ["recent_trades", "late_reports", "congress_trader"],
-      },
-      name: {
-        type: "string",
-        description: "Congress member name (for congress_trader action)",
-      },
-      ticker: {
-        type: "string",
-        description: "Filter by ticker symbol",
-      },
-      date: {
-        type: "string",
-        description: "Date filter in YYYY-MM-DD format",
-      },
-      limit: {
-        type: "number",
-        description: "Maximum number of results (default 100, max 200)",
-      },
-    },
-    required: ["action"],
-  },
+  inputSchema: toJsonSchema(congressInputSchema),
   annotations: {
     readOnlyHint: true,
     openWorldHint: true,
@@ -48,30 +35,35 @@ Available actions:
  * @returns JSON string with congress trading data or error message
  */
 export async function handleCongress(args: Record<string, unknown>): Promise<string> {
-  const { action, name, ticker, date, limit } = args
+  const parsed = congressInputSchema.safeParse(args)
+  if (!parsed.success) {
+    return formatError(`Invalid input: ${formatZodError(parsed.error)}`)
+  }
+
+  const { action, name, ticker, date, limit } = parsed.data
 
   switch (action) {
     case "recent_trades":
       return formatResponse(await uwFetch("/api/congress/recent-trades", {
-        date: date as string,
-        ticker: ticker as string,
-        limit: limit as number,
+        date,
+        ticker,
+        limit,
       }))
 
     case "late_reports":
       return formatResponse(await uwFetch("/api/congress/late-reports", {
-        date: date as string,
-        ticker: ticker as string,
-        limit: limit as number,
+        date,
+        ticker,
+        limit,
       }))
 
     case "congress_trader":
       if (!name) return formatError("name is required")
       return formatResponse(await uwFetch("/api/congress/congress-trader", {
-        name: name as string,
-        date: date as string,
-        ticker: ticker as string,
-        limit: limit as number,
+        name,
+        date,
+        ticker,
+        limit,
       }))
 
     default:

--- a/src/tools/flow.ts
+++ b/src/tools/flow.ts
@@ -1,4 +1,39 @@
+import { z } from "zod"
 import { uwFetch, formatResponse, encodePath, formatError } from "../client.js"
+import {
+  toJsonSchema,
+  tickerSchema,
+  dateSchema,
+  expirySchema,
+  limitSchema,
+  optionTypeSchema,
+  orderSchema,
+  flowGroupSchema,
+  premiumFilterSchema,
+  sizeFilterSchema,
+  oiFilterSchema,
+  dteFilterSchema,
+  flowTradeFiltersSchema,
+  formatZodError,
+} from "../schemas.js"
+
+const flowActions = ["flow_alerts", "full_tape", "net_flow_expiry", "group_greek_flow", "group_greek_flow_expiry"] as const
+
+const flowInputSchema = z.object({
+  action: z.enum(flowActions).describe("The action to perform"),
+  date: dateSchema.optional(),
+  flow_group: flowGroupSchema.optional(),
+  expiry: expirySchema.optional(),
+  ticker: tickerSchema.describe("Ticker symbol filter").optional(),
+  limit: limitSchema.optional(),
+  side: optionTypeSchema.describe("Trade side (call or put)").optional(),
+  order: orderSchema.optional(),
+}).merge(premiumFilterSchema)
+  .merge(sizeFilterSchema)
+  .merge(oiFilterSchema)
+  .merge(dteFilterSchema)
+  .merge(flowTradeFiltersSchema)
+
 
 export const flowTool = {
   name: "uw_flow",
@@ -14,100 +49,7 @@ Available actions:
 Flow groups: airline, bank, basic materials, china, communication services, consumer cyclical, consumer defensive, crypto, cyber, energy, financial services, gas, gold, healthcare, industrials, mag7, oil, real estate, refiners, reit, semi, silver, technology, uranium, utilities
 
 Flow alerts filtering options include: ticker, premium range, volume range, OI range, DTE range, and more.`,
-  inputSchema: {
-    type: "object" as const,
-    properties: {
-      action: {
-        type: "string",
-        description: "The action to perform",
-        enum: ["flow_alerts", "full_tape", "net_flow_expiry", "group_greek_flow", "group_greek_flow_expiry"],
-      },
-      date: {
-        type: "string",
-        description: "Date in YYYY-MM-DD format",
-      },
-      flow_group: {
-        type: "string",
-        description: "Flow group (e.g., mag7, semi, bank, energy, crypto)",
-        enum: ["airline", "bank", "basic materials", "china", "communication services", "consumer cyclical", "consumer defensive", "crypto", "cyber", "energy", "financial services", "gas", "gold", "healthcare", "industrials", "mag7", "oil", "real estate", "refiners", "reit", "semi", "silver", "technology", "uranium", "utilities"],
-      },
-      expiry: {
-        type: "string",
-        description: "Option expiry date in YYYY-MM-DD format",
-      },
-      ticker: {
-        type: "string",
-        description: "Ticker symbol filter",
-      },
-      limit: {
-        type: "number",
-        description: "Maximum number of results",
-      },
-      min_premium: {
-        type: "number",
-        description: "Minimum premium filter",
-      },
-      max_premium: {
-        type: "number",
-        description: "Maximum premium filter",
-      },
-      min_size: {
-        type: "number",
-        description: "Minimum size/volume filter",
-      },
-      max_size: {
-        type: "number",
-        description: "Maximum size/volume filter",
-      },
-      min_oi: {
-        type: "number",
-        description: "Minimum open interest filter",
-      },
-      max_oi: {
-        type: "number",
-        description: "Maximum open interest filter",
-      },
-      min_dte: {
-        type: "number",
-        description: "Minimum days to expiration",
-      },
-      max_dte: {
-        type: "number",
-        description: "Maximum days to expiration",
-      },
-      is_floor: {
-        type: "boolean",
-        description: "Filter for floor trades",
-      },
-      is_sweep: {
-        type: "boolean",
-        description: "Filter for sweep trades",
-      },
-      is_multi_leg: {
-        type: "boolean",
-        description: "Filter for multi-leg trades",
-      },
-      is_unusual: {
-        type: "boolean",
-        description: "Filter for unusual trades",
-      },
-      is_golden_sweep: {
-        type: "boolean",
-        description: "Filter for golden sweep trades",
-      },
-      side: {
-        type: "string",
-        description: "Trade side (call or put)",
-        enum: ["call", "put"],
-      },
-      order: {
-        type: "string",
-        description: "Order direction",
-        enum: ["asc", "desc"],
-      },
-    },
-    required: ["action"],
-  },
+  inputSchema: toJsonSchema(flowInputSchema),
   annotations: {
     readOnlyHint: true,
     openWorldHint: true,
@@ -121,6 +63,11 @@ Flow alerts filtering options include: ticker, premium range, volume range, OI r
  * @returns JSON string with flow data or error message
  */
 export async function handleFlow(args: Record<string, unknown>): Promise<string> {
+  const parsed = flowInputSchema.safeParse(args)
+  if (!parsed.success) {
+    return formatError(`Invalid input: ${formatZodError(parsed.error)}`)
+  }
+
   const {
     action,
     date,
@@ -143,29 +90,29 @@ export async function handleFlow(args: Record<string, unknown>): Promise<string>
     is_golden_sweep,
     side,
     order,
-  } = args
+  } = parsed.data
 
   switch (action) {
     case "flow_alerts":
       return formatResponse(await uwFetch("/api/option-trades/flow-alerts", {
-        date: date as string,
-        ticker_symbol: ticker as string,
-        limit: limit as number,
-        min_premium: min_premium as number,
-        max_premium: max_premium as number,
-        min_size: min_size as number,
-        max_size: max_size as number,
-        min_oi: min_oi as number,
-        max_oi: max_oi as number,
-        min_dte: min_dte as number,
-        max_dte: max_dte as number,
-        is_floor: is_floor as boolean,
-        is_sweep: is_sweep as boolean,
-        is_multi_leg: is_multi_leg as boolean,
-        is_unusual: is_unusual as boolean,
-        is_golden_sweep: is_golden_sweep as boolean,
-        side: side as string,
-        order: order as string,
+        date,
+        ticker_symbol: ticker,
+        limit,
+        min_premium,
+        max_premium,
+        min_size,
+        max_size,
+        min_oi,
+        max_oi,
+        min_dte,
+        max_dte,
+        is_floor,
+        is_sweep,
+        is_multi_leg,
+        is_unusual,
+        is_golden_sweep,
+        side,
+        order,
       }))
 
     case "full_tape":
@@ -173,15 +120,15 @@ export async function handleFlow(args: Record<string, unknown>): Promise<string>
       return formatResponse(await uwFetch(`/api/option-trades/full-tape/${encodePath(date)}`))
 
     case "net_flow_expiry":
-      return formatResponse(await uwFetch("/api/net-flow/expiry", { date: date as string }))
+      return formatResponse(await uwFetch("/api/net-flow/expiry", { date }))
 
     case "group_greek_flow":
       if (!flow_group) return formatError("flow_group is required")
-      return formatResponse(await uwFetch(`/api/group-flow/${encodePath(flow_group)}/greek-flow`, { date: date as string }))
+      return formatResponse(await uwFetch(`/api/group-flow/${encodePath(flow_group)}/greek-flow`, { date }))
 
     case "group_greek_flow_expiry":
       if (!flow_group || !expiry) return formatError("flow_group and expiry are required")
-      return formatResponse(await uwFetch(`/api/group-flow/${encodePath(flow_group)}/greek-flow/${encodePath(expiry)}`, { date: date as string }))
+      return formatResponse(await uwFetch(`/api/group-flow/${encodePath(flow_group)}/greek-flow/${encodePath(expiry)}`, { date }))
 
     default:
       return formatError(`Unknown action: ${action}`)

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -1,0 +1,65 @@
+import { stockTool, handleStock } from "./stock.js"
+import { optionsTool, handleOptions } from "./options.js"
+import { marketTool, handleMarket } from "./market.js"
+import { flowTool, handleFlow } from "./flow.js"
+import { darkpoolTool, handleDarkpool } from "./darkpool.js"
+import { congressTool, handleCongress } from "./congress.js"
+import { insiderTool, handleInsider } from "./insider.js"
+import { institutionsTool, handleInstitutions } from "./institutions.js"
+import { earningsTool, handleEarnings } from "./earnings.js"
+import { etfTool, handleEtf } from "./etf.js"
+import { screenerTool, handleScreener } from "./screener.js"
+import { shortsTool, handleShorts } from "./shorts.js"
+import { seasonalityTool, handleSeasonality } from "./seasonality.js"
+import { newsTool, handleNews } from "./news.js"
+import { alertsTool, handleAlerts } from "./alerts.js"
+import { politiciansTool, handlePoliticians } from "./politicians.js"
+
+export type ToolHandler = (args: Record<string, unknown>) => Promise<string>
+
+export interface ToolDefinition {
+  name: string
+  description: string
+  inputSchema: {
+    type: "object"
+    properties: Record<string, unknown>
+    required: string[]
+  }
+  annotations?: {
+    title?: string
+    readOnlyHint?: boolean
+    destructiveHint?: boolean
+    idempotentHint?: boolean
+    openWorldHint?: boolean
+  }
+}
+
+interface ToolRegistration {
+  tool: ToolDefinition
+  handler: ToolHandler
+}
+
+const toolRegistrations: ToolRegistration[] = [
+  { tool: stockTool, handler: handleStock },
+  { tool: optionsTool, handler: handleOptions },
+  { tool: marketTool, handler: handleMarket },
+  { tool: flowTool, handler: handleFlow },
+  { tool: darkpoolTool, handler: handleDarkpool },
+  { tool: congressTool, handler: handleCongress },
+  { tool: insiderTool, handler: handleInsider },
+  { tool: institutionsTool, handler: handleInstitutions },
+  { tool: earningsTool, handler: handleEarnings },
+  { tool: etfTool, handler: handleEtf },
+  { tool: screenerTool, handler: handleScreener },
+  { tool: shortsTool, handler: handleShorts },
+  { tool: seasonalityTool, handler: handleSeasonality },
+  { tool: newsTool, handler: handleNews },
+  { tool: alertsTool, handler: handleAlerts },
+  { tool: politiciansTool, handler: handlePoliticians },
+]
+
+export const tools = toolRegistrations.map((reg) => reg.tool)
+
+export const handlers: Record<string, ToolHandler> = Object.fromEntries(
+  toolRegistrations.map((reg) => [reg.tool.name, reg.handler]),
+)

--- a/src/tools/market.ts
+++ b/src/tools/market.ts
@@ -1,4 +1,43 @@
+import { z } from "zod"
 import { uwFetch, formatResponse, encodePath, formatError } from "../client.js"
+import { toJsonSchema, tickerSchema, dateSchema, limitSchema, orderSchema, formatZodError } from "../schemas.js"
+
+const marketActions = [
+  "market_tide",
+  "sector_tide",
+  "etf_tide",
+  "sector_etfs",
+  "economic_calendar",
+  "fda_calendar",
+  "correlations",
+  "insider_buy_sells",
+  "oi_change",
+  "spike",
+  "top_net_impact",
+  "total_options_volume",
+] as const
+
+const marketInputSchema = z.object({
+  action: z.enum(marketActions).describe("The action to perform"),
+  ticker: tickerSchema.describe("Ticker symbol (for etf_tide)").optional(),
+  tickers: z.string().describe("Comma-separated list of tickers (for correlations)").optional(),
+  sector: z.string().describe("Market sector (for sector_tide)").optional(),
+  date: dateSchema.optional(),
+  otm_only: z.boolean().describe("Only use OTM options (for market_tide)").optional(),
+  interval_5m: z.boolean().describe("Use 5-minute intervals instead of 1-minute (for market_tide)").optional(),
+  interval: z.string().describe("Time interval (1y, 6m, 3m, 1m) for correlations").optional(),
+  start_date: z.string().describe("Start date for correlations (YYYY-MM-DD)").optional(),
+  end_date: z.string().describe("End date for correlations (YYYY-MM-DD)").optional(),
+  limit: limitSchema.optional(),
+  order: orderSchema.optional(),
+  issue_types: z.string().describe("Issue types filter (for top_net_impact)").optional(),
+  announced_date_min: z.string().describe("Minimum announced date for FDA calendar").optional(),
+  announced_date_max: z.string().describe("Maximum announced date for FDA calendar").optional(),
+  target_date_min: z.string().describe("Minimum target date for FDA calendar").optional(),
+  target_date_max: z.string().describe("Maximum target date for FDA calendar").optional(),
+  drug: z.string().describe("Drug name filter for FDA calendar").optional(),
+})
+
 
 export const marketTool = {
   name: "uw_market",
@@ -17,99 +56,7 @@ Available actions:
 - spike: Get SPIKE values (date optional)
 - top_net_impact: Get top tickers by net premium (date, issue_types, limit optional)
 - total_options_volume: Get total market options volume (limit optional)`,
-  inputSchema: {
-    type: "object" as const,
-    properties: {
-      action: {
-        type: "string",
-        description: "The action to perform",
-        enum: [
-          "market_tide",
-          "sector_tide",
-          "etf_tide",
-          "sector_etfs",
-          "economic_calendar",
-          "fda_calendar",
-          "correlations",
-          "insider_buy_sells",
-          "oi_change",
-          "spike",
-          "top_net_impact",
-          "total_options_volume",
-        ],
-      },
-      ticker: {
-        type: "string",
-        description: "Ticker symbol (for etf_tide)",
-      },
-      tickers: {
-        type: "string",
-        description: "Comma-separated list of tickers (for correlations)",
-      },
-      sector: {
-        type: "string",
-        description: "Market sector (for sector_tide)",
-      },
-      date: {
-        type: "string",
-        description: "Date in YYYY-MM-DD format",
-      },
-      otm_only: {
-        type: "boolean",
-        description: "Only use OTM options (for market_tide)",
-      },
-      interval_5m: {
-        type: "boolean",
-        description: "Use 5-minute intervals instead of 1-minute (for market_tide)",
-      },
-      interval: {
-        type: "string",
-        description: "Time interval (1y, 6m, 3m, 1m) for correlations",
-      },
-      start_date: {
-        type: "string",
-        description: "Start date for correlations (YYYY-MM-DD)",
-      },
-      end_date: {
-        type: "string",
-        description: "End date for correlations (YYYY-MM-DD)",
-      },
-      limit: {
-        type: "number",
-        description: "Maximum number of results",
-      },
-      order: {
-        type: "string",
-        description: "Order direction (asc or desc)",
-        enum: ["asc", "desc"],
-      },
-      issue_types: {
-        type: "string",
-        description: "Issue types filter (for top_net_impact)",
-      },
-      announced_date_min: {
-        type: "string",
-        description: "Minimum announced date for FDA calendar",
-      },
-      announced_date_max: {
-        type: "string",
-        description: "Maximum announced date for FDA calendar",
-      },
-      target_date_min: {
-        type: "string",
-        description: "Minimum target date for FDA calendar",
-      },
-      target_date_max: {
-        type: "string",
-        description: "Maximum target date for FDA calendar",
-      },
-      drug: {
-        type: "string",
-        description: "Drug name filter for FDA calendar",
-      },
-    },
-    required: ["action"],
-  },
+  inputSchema: toJsonSchema(marketInputSchema),
   annotations: {
     readOnlyHint: true,
     openWorldHint: true,
@@ -123,6 +70,11 @@ Available actions:
  * @returns JSON string with market data or error message
  */
 export async function handleMarket(args: Record<string, unknown>): Promise<string> {
+  const parsed = marketInputSchema.safeParse(args)
+  if (!parsed.success) {
+    return formatError(`Invalid input: ${formatZodError(parsed.error)}`)
+  }
+
   const {
     action,
     ticker,
@@ -142,23 +94,23 @@ export async function handleMarket(args: Record<string, unknown>): Promise<strin
     target_date_min,
     target_date_max,
     drug,
-  } = args
+  } = parsed.data
 
   switch (action) {
     case "market_tide":
       return formatResponse(await uwFetch("/api/market/market-tide", {
-        date: date as string,
-        otm_only: otm_only as boolean,
-        interval_5m: interval_5m as boolean,
+        date,
+        otm_only,
+        interval_5m,
       }))
 
     case "sector_tide":
       if (!sector) return formatError("sector is required")
-      return formatResponse(await uwFetch(`/api/market/${encodePath(sector)}/sector-tide`, { date: date as string }))
+      return formatResponse(await uwFetch(`/api/market/${encodePath(sector)}/sector-tide`, { date }))
 
     case "etf_tide":
       if (!ticker) return formatError("ticker is required")
-      return formatResponse(await uwFetch(`/api/market/${encodePath(ticker)}/etf-tide`, { date: date as string }))
+      return formatResponse(await uwFetch(`/api/market/${encodePath(ticker)}/etf-tide`, { date }))
 
     case "sector_etfs":
       return formatResponse(await uwFetch("/api/market/sector-etfs"))
@@ -168,46 +120,46 @@ export async function handleMarket(args: Record<string, unknown>): Promise<strin
 
     case "fda_calendar":
       return formatResponse(await uwFetch("/api/market/fda-calendar", {
-        announced_date_min: announced_date_min as string,
-        announced_date_max: announced_date_max as string,
-        target_date_min: target_date_min as string,
-        target_date_max: target_date_max as string,
-        drug: drug as string,
-        ticker: ticker as string,
-        limit: limit as number,
+        announced_date_min,
+        announced_date_max,
+        target_date_min,
+        target_date_max,
+        drug,
+        ticker,
+        limit,
       }))
 
     case "correlations":
       if (!tickers) return formatError("tickers is required (comma-separated)")
       return formatResponse(await uwFetch("/api/market/correlations", {
-        tickers: tickers as string,
-        interval: interval as string,
-        start_date: start_date as string,
-        end_date: end_date as string,
+        tickers,
+        interval,
+        start_date,
+        end_date,
       }))
 
     case "insider_buy_sells":
-      return formatResponse(await uwFetch("/api/market/insider-buy-sells", { limit: limit as number }))
+      return formatResponse(await uwFetch("/api/market/insider-buy-sells", { limit }))
 
     case "oi_change":
       return formatResponse(await uwFetch("/api/market/oi-change", {
-        date: date as string,
-        limit: limit as number,
-        order: order as string,
+        date,
+        limit,
+        order,
       }))
 
     case "spike":
-      return formatResponse(await uwFetch("/api/market/spike", { date: date as string }))
+      return formatResponse(await uwFetch("/api/market/spike", { date }))
 
     case "top_net_impact":
       return formatResponse(await uwFetch("/api/market/top-net-impact", {
-        date: date as string,
-        "issue_types[]": issue_types as string,
-        limit: limit as number,
+        date,
+        "issue_types[]": issue_types,
+        limit,
       }))
 
     case "total_options_volume":
-      return formatResponse(await uwFetch("/api/market/total-options-volume", { limit: limit as number }))
+      return formatResponse(await uwFetch("/api/market/total-options-volume", { limit }))
 
     default:
       return formatError(`Unknown action: ${action}`)

--- a/src/tools/news.ts
+++ b/src/tools/news.ts
@@ -1,4 +1,16 @@
+import { z } from "zod"
 import { uwFetch, formatResponse, formatError } from "../client.js"
+import { toJsonSchema, tickerSchema, limitSchema, formatZodError,
+} from "../schemas.js"
+
+const newsActions = ["headlines"] as const
+
+const newsInputSchema = z.object({
+  action: z.enum(newsActions).describe("The action to perform"),
+  ticker: tickerSchema.describe("Filter by ticker symbol").optional(),
+  limit: limitSchema.optional(),
+})
+
 
 export const newsTool = {
   name: "uw_news",
@@ -6,25 +18,7 @@ export const newsTool = {
 
 Available actions:
 - headlines: Get news headlines with optional ticker filter`,
-  inputSchema: {
-    type: "object" as const,
-    properties: {
-      action: {
-        type: "string",
-        description: "The action to perform",
-        enum: ["headlines"],
-      },
-      ticker: {
-        type: "string",
-        description: "Filter by ticker symbol",
-      },
-      limit: {
-        type: "number",
-        description: "Maximum number of results",
-      },
-    },
-    required: ["action"],
-  },
+  inputSchema: toJsonSchema(newsInputSchema),
   annotations: {
     readOnlyHint: true,
     openWorldHint: true,
@@ -38,13 +32,18 @@ Available actions:
  * @returns JSON string with news data or error message
  */
 export async function handleNews(args: Record<string, unknown>): Promise<string> {
-  const { action, ticker, limit } = args
+  const parsed = newsInputSchema.safeParse(args)
+  if (!parsed.success) {
+    return formatError(`Invalid input: ${formatZodError(parsed.error)}`)
+  }
+
+  const { action, ticker, limit } = parsed.data
 
   switch (action) {
     case "headlines":
       return formatResponse(await uwFetch("/api/news/headlines", {
-        ticker: ticker as string,
-        limit: limit as number,
+        ticker,
+        limit,
       }))
 
     default:


### PR DESCRIPTION
## Summary

- Add Zod as production dependency for runtime input validation
- Create shared, reusable schemas in `src/schemas.ts` (ticker, date, expiry, limit, premium/size/volume filters)
- Refactor all 16 tool files to use Zod schemas with `toJsonSchema()` for MCP tool definitions
- Add centralized tool exports in `src/tools/index.ts` to simplify main entry point
- Add MCP Inspector debugging instructions to README
- Bump Node.js engine requirement to >=20.0.0

## Test plan

- [ ] Run `npm run build` to verify TypeScript compilation
- [ ] Run `npm run lint` to check for linting issues
- [ ] Test with MCP Inspector to verify tools work correctly
- [ ] Verify Zod validation errors are properly formatted and returned

Closes #4