### PR TITLE
feat(issue-5): add sliding window rate limiter for API requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,17 @@ Add to your config file:
 }
 ```
 
+## Configuration
+
+### Environment Variables
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `UW_API_KEY` | Your Unusual Whales API key (required) | - |
+| `UW_RATE_LIMIT_PER_MINUTE` | Max requests per minute | `120` |
+
+The server includes a sliding window rate limiter to prevent exceeding API limits. The Unusual Whales API allows 120 requests/minute and 15,000 requests/day by default (some plans may differ). If you have a custom rate limit or want to adjust the MCP server's limit, set `UW_RATE_LIMIT_PER_MINUTE` accordingly.
+
 ## Usage
 
 Once configured, ask Claude about market data:

--- a/src/rate-limiter.ts
+++ b/src/rate-limiter.ts
@@ -1,0 +1,37 @@
+const ONE_MINUTE_MS = 60_000
+
+/**
+ * Sliding window rate limiter to prevent exceeding API rate limits.
+ * Tracks request timestamps and rejects requests that would exceed the limit.
+ */
+export class SlidingWindowRateLimiter {
+  private timestamps: number[] = []
+  private readonly maxRequests: number
+  private readonly windowMs: number
+
+  constructor(maxRequestsPerMinute: number) {
+    this.maxRequests = maxRequestsPerMinute
+    this.windowMs = ONE_MINUTE_MS
+  }
+
+  /**
+   * Check if a request can proceed. If yes, records the request.
+   * @returns Object with allowed boolean and waitMs if rate limited
+   */
+  tryAcquire(): { allowed: boolean; waitMs?: number } {
+    const now = Date.now()
+
+    // Remove timestamps outside the sliding window
+    this.timestamps = this.timestamps.filter(t => now - t < this.windowMs)
+
+    if (this.timestamps.length >= this.maxRequests) {
+      // Calculate how long until the oldest request exits the window
+      const oldestTimestamp = this.timestamps[0]
+      const waitMs = this.windowMs - (now - oldestTimestamp)
+      return { allowed: false, waitMs }
+    }
+
+    this.timestamps.push(now)
+    return { allowed: true }
+  }
+}


### PR DESCRIPTION
## Summary

- Add `SlidingWindowRateLimiter` class in `src/rate-limiter.ts` to prevent exceeding API rate limits
- Integrate rate limiting into `uwFetch` with configurable limit (default 120 req/min)
- Add `UW_RATE_LIMIT_PER_MINUTE` environment variable for custom rate limits
- Handle 429 responses from API with clear error messages
- Document rate limiting configuration in README

## Test plan

- [ ] Build passes (`npm run build`)
- [ ] Lint passes (`npm run lint`)
- [ ] Test rate limiter by making rapid requests and verifying throttling
- [ ] Verify custom rate limit via `UW_RATE_LIMIT_PER_MINUTE` env var

Closes #5