### PR TITLE
fix(issue-24): add min_share_value and max_share_value filter parameters

### DIFF
--- a/src/tools/institutions.ts
+++ b/src/tools/institutions.ts
@@ -18,6 +18,8 @@ const institutionsInputSchema = z.object({
   order_direction: orderSchema.describe("Order direction (asc or desc)").optional(),
   min_total_value: z.number().describe("Minimum total value filter").optional(),
   max_total_value: z.number().describe("Maximum total value filter").optional(),
+  min_share_value: z.number().describe("Minimum share value filter").optional(),
+  max_share_value: z.number().describe("Maximum share value filter").optional(),
   tags: z.string().describe("Institution tags filter").optional(),
   security_types: z.string().describe("Security types filter").optional(),
 })
@@ -66,6 +68,8 @@ export async function handleInstitutions(args: Record<string, unknown>): Promise
     order_direction,
     min_total_value,
     max_total_value,
+    min_share_value,
+    max_share_value,
     tags,
     security_types,
   } = parsed.data
@@ -76,6 +80,8 @@ export async function handleInstitutions(args: Record<string, unknown>): Promise
         name,
         min_total_value,
         max_total_value,
+        min_share_value,
+        max_share_value,
         "tags[]": tags,
         order,
         order_direction,


### PR DESCRIPTION
## Summary

Adds two missing optional parameters to the institutions tool for the `/api/institutions` endpoint:
- `min_share_value` - Filter institutions by minimum share value
- `max_share_value` - Filter institutions by maximum share value

## Changes

- Added `min_share_value` and `max_share_value` to the Zod input schema with `z.number().optional()` type
- Added parameters to the destructuring of parsed input data
- Passed parameters to the `/api/institutions` endpoint in the `uwFetch` call

## Why

These parameters were identified as missing optional API parameters that the Unusual Whales API supports but were not being passed through by the MCP tool. Adding them improves filtering capabilities for institutional data queries.

Closes #24