### PR TITLE
fix(issue-25): add missing optional parameters to headlines endpoint

### DIFF
--- a/src/tools/news.ts
+++ b/src/tools/news.ts
@@ -9,6 +9,10 @@ const newsInputSchema = z.object({
   action: z.enum(newsActions).describe("The action to perform"),
   ticker: tickerSchema.describe("Filter by ticker symbol").optional(),
   limit: limitSchema.optional(),
+  sources: z.string().describe("Filter by news sources").optional(),
+  search_term: z.string().describe("Search term to filter headlines").optional(),
+  major_only: z.boolean().describe("Only include major news").optional(),
+  page: z.number().describe("Page number for pagination").optional(),
 })
 
 
@@ -17,7 +21,7 @@ export const newsTool = {
   description: `Access UnusualWhales news headlines.
 
 Available actions:
-- headlines: Get news headlines with optional ticker filter`,
+- headlines: Get news headlines with optional filters (ticker, sources, search_term, major_only, page)`,
   inputSchema: toJsonSchema(newsInputSchema),
   annotations: {
     readOnlyHint: true,
@@ -37,13 +41,17 @@ export async function handleNews(args: Record<string, unknown>): Promise<string>
     return formatError(`Invalid input: ${formatZodError(parsed.error)}`)
   }
 
-  const { action, ticker, limit } = parsed.data
+  const { action, ticker, limit, sources, search_term, major_only, page } = parsed.data
 
   switch (action) {
     case "headlines":
       return formatResponse(await uwFetch("/api/news/headlines", {
         ticker,
         limit,
+        sources,
+        search_term,
+        major_only,
+        page,
       }))
 
     default:


### PR DESCRIPTION
## Summary

Adds 4 missing optional API parameters to the news tool's `/api/news/headlines` endpoint, improving filtering and pagination functionality.

## Changes

Added the following optional parameters to `src/tools/news.ts`:

| Parameter | Type | Description |
|-----------|------|-------------|
| `sources` | string | Filter headlines by specific news sources |
| `search_term` | string | Search term to filter headlines |
| `major_only` | boolean | Only include major/significant news |
| `page` | number | Page number for pagination support |

## Implementation Details

- Added parameters to the Zod input schema with appropriate types and descriptions
- Updated the `handleNews` function to destructure and pass new parameters to `uwFetch`
- Updated tool description to document all available filter options

Closes #25