### PR TITLE
fix(issue-26): add 7 missing optional parameters to options tool

### DIFF
--- a/src/tools/options.ts
+++ b/src/tools/options.ts
@@ -1,6 +1,11 @@
 import { z } from "zod"
 import { uwFetch, formatResponse, encodePath, formatError } from "../client.js"
-import { toJsonSchema, formatZodError,
+import {
+  toJsonSchema,
+  formatZodError,
+  dateSchema,
+  limitSchema,
+  optionTypeSchema,
 } from "../schemas.js"
 
 const optionsActions = ["flow", "historic", "intraday", "volume_profile"] as const
@@ -8,6 +13,12 @@ const optionsActions = ["flow", "historic", "intraday", "volume_profile"] as con
 const optionsInputSchema = z.object({
   action: z.enum(optionsActions).describe("The action to perform"),
   id: z.string().describe("Option contract ID/symbol (e.g., AAPL240119C00150000)"),
+  // flow action parameters
+  side: optionTypeSchema.describe("Trade side (call or put)").optional(),
+  min_premium: z.number().nonnegative("Premium cannot be negative").describe("Minimum premium filter").optional(),
+  limit: limitSchema.optional(),
+  // date parameter used by flow, intraday, and volume_profile actions
+  date: dateSchema.optional(),
 })
 
 
@@ -16,10 +27,10 @@ export const optionsTool = {
   description: `Access UnusualWhales option contract data including flow, historic prices, intraday data, and volume profiles.
 
 Available actions:
-- flow: Get option contract flow (id required)
-- historic: Get historic option contract data (id required)
-- intraday: Get intraday option contract data (id required)
-- volume_profile: Get volume profile for option contract (id required)
+- flow: Get option contract flow (id required; side, min_premium, limit, date optional)
+- historic: Get historic option contract data (id required; limit optional)
+- intraday: Get intraday option contract data (id required; date optional)
+- volume_profile: Get volume profile for option contract (id required; date optional)
 
 The 'id' parameter is the option contract symbol (e.g., AAPL240119C00150000).`,
   inputSchema: toJsonSchema(optionsInputSchema),
@@ -41,21 +52,26 @@ export async function handleOptions(args: Record<string, unknown>): Promise<stri
     return formatError(`Invalid input: ${formatZodError(parsed.error)}`)
   }
 
-  const { action, id } = parsed.data
+  const { action, id, side, min_premium, limit, date } = parsed.data
   const safeId = encodePath(id)
 
   switch (action) {
     case "flow":
-      return formatResponse(await uwFetch(`/api/option-contract/${safeId}/flow`))
+      return formatResponse(await uwFetch(`/api/option-contract/${safeId}/flow`, {
+        side,
+        min_premium,
+        limit,
+        date,
+      }))
 
     case "historic":
-      return formatResponse(await uwFetch(`/api/option-contract/${safeId}/historic`))
+      return formatResponse(await uwFetch(`/api/option-contract/${safeId}/historic`, { limit }))
 
     case "intraday":
-      return formatResponse(await uwFetch(`/api/option-contract/${safeId}/intraday`))
+      return formatResponse(await uwFetch(`/api/option-contract/${safeId}/intraday`, { date }))
 
     case "volume_profile":
-      return formatResponse(await uwFetch(`/api/option-contract/${safeId}/volume-profile`))
+      return formatResponse(await uwFetch(`/api/option-contract/${safeId}/volume-profile`, { date }))
 
     default:
       return formatError(`Unknown action: ${action}`)


### PR DESCRIPTION
## Summary

Adds 7 missing optional API parameters to the options tool to improve filtering and functionality for option contract data queries.

## Changes

### New Optional Parameters

| Endpoint | Parameters Added |
|----------|-----------------|
| `/api/option-contract/{id}/flow` | `side`, `min_premium`, `limit`, `date` |
| `/api/option-contract/{id}/historic` | `limit` |
| `/api/option-contract/{id}/intraday` | `date` |
| `/api/option-contract/{id}/volume-profile` | `date` |

### Implementation Details

- Added `side` parameter using existing `optionTypeSchema` (call/put) for filtering flow by trade side
- Added `min_premium` parameter for filtering flow by minimum premium amount
- Added `limit` parameter for controlling result count on flow and historic endpoints
- Added `date` parameter (YYYY-MM-DD format) for filtering flow, intraday, and volume_profile by specific date
- Updated tool description to document which optional parameters are available for each action
- Reused existing shared schemas (`dateSchema`, `limitSchema`, `optionTypeSchema`) for consistency

## Related Issue

Closes #26