### PR TITLE
fix(issue-27 ): add 10 missing optional API parameters

### DIFF
--- a/src/tools/politicians.ts
+++ b/src/tools/politicians.ts
@@ -1,18 +1,25 @@
 import { z } from "zod"
 import { uwFetch, formatResponse, encodePath, formatError } from "../client.js"
-import { toJsonSchema, tickerSchema, limitSchema, formatZodError,
+import { toJsonSchema, tickerSchema, limitSchema, dateSchema, formatZodError,
 } from "../schemas.js"
 
 const politiciansActions = ["people", "portfolio", "recent_trades", "holders", "disclosures"] as const
 
 const politiciansInputSchema = z.object({
   action: z.enum(politiciansActions).describe("The action to perform"),
-  politician_id: z.string().describe("Politician ID (for portfolio or disclosures action)").optional(),
+  politician_id: z.string().describe("Politician ID (for portfolio, recent_trades, or disclosures action)").optional(),
   latest_only: z.boolean().describe("Return only most recent disclosure per politician (for disclosures action)").optional(),
   year: z.number().describe("Filter by disclosure year (for disclosures action)").optional(),
-  ticker: tickerSchema.describe("Ticker symbol (for holders action)").optional(),
+  ticker: tickerSchema.describe("Ticker symbol (for holders or recent_trades action)").optional(),
   limit: limitSchema.optional(),
   page: z.number().describe("Page number for pagination").optional(),
+  aggregate_all_portfolios: z.boolean().describe("Aggregate all portfolios (for portfolio or holders action)").optional(),
+  date: dateSchema.describe("Filter by date in YYYY-MM-DD format (for recent_trades action)").optional(),
+  filter_late_reports: z.boolean().describe("Filter out late reports (for recent_trades action)").optional(),
+  disclosure_newer_than: dateSchema.describe("Filter disclosures newer than date in YYYY-MM-DD format (for recent_trades action)").optional(),
+  disclosure_older_than: dateSchema.describe("Filter disclosures older than date in YYYY-MM-DD format (for recent_trades action)").optional(),
+  transaction_newer_than: dateSchema.describe("Filter transactions newer than date in YYYY-MM-DD format (for recent_trades action)").optional(),
+  transaction_older_than: dateSchema.describe("Filter transactions older than date in YYYY-MM-DD format (for recent_trades action)").optional(),
 })
 
 
@@ -22,9 +29,9 @@ export const politiciansTool = {
 
 Available actions:
 - people: List all politicians
-- portfolio: Get a politician's portfolio (politician_id required)
-- recent_trades: Get recent politician trades
-- holders: Get politicians holding a ticker (ticker required)
+- portfolio: Get a politician's portfolio (politician_id required; optional: aggregate_all_portfolios)
+- recent_trades: Get recent politician trades (optional: date, ticker, politician_id, filter_late_reports, disclosure_newer_than, disclosure_older_than, transaction_newer_than, transaction_older_than)
+- holders: Get politicians holding a ticker (ticker required; optional: aggregate_all_portfolios)
 - disclosures: Get annual disclosure file records (optional: politician_id, latest_only, year)`,
   inputSchema: toJsonSchema(politiciansInputSchema),
   annotations: {
@@ -45,7 +52,12 @@ export async function handlePoliticians(args: Record<string, unknown>): Promise<
     return formatError(`Invalid input: ${formatZodError(parsed.error)}`)
   }
 
-  const { action, politician_id, ticker, limit, page, latest_only, year } = parsed.data
+  const {
+    action, politician_id, ticker, limit, page, latest_only, year,
+    aggregate_all_portfolios, date, filter_late_reports,
+    disclosure_newer_than, disclosure_older_than,
+    transaction_newer_than, transaction_older_than,
+  } = parsed.data
 
   switch (action) {
     case "people":
@@ -53,17 +65,29 @@ export async function handlePoliticians(args: Record<string, unknown>): Promise<
 
     case "portfolio":
       if (!politician_id) return formatError("politician_id is required")
-      return formatResponse(await uwFetch(`/api/politician-portfolios/${encodePath(politician_id)}`))
+      return formatResponse(await uwFetch(`/api/politician-portfolios/${encodePath(politician_id)}`, {
+        aggregate_all_portfolios,
+      }))
 
     case "recent_trades":
       return formatResponse(await uwFetch("/api/politician-portfolios/recent_trades", {
         limit,
         page,
+        date,
+        ticker,
+        politician_id,
+        filter_late_reports,
+        disclosure_newer_than,
+        disclosure_older_than,
+        transaction_newer_than,
+        transaction_older_than,
       }))
 
     case "holders":
       if (!ticker) return formatError("ticker is required")
-      return formatResponse(await uwFetch(`/api/politician-portfolios/holders/${encodePath(ticker)}`))
+      return formatResponse(await uwFetch(`/api/politician-portfolios/holders/${encodePath(ticker)}`, {
+        aggregate_all_portfolios,
+      }))
 
     case "disclosures":
       return formatResponse(await uwFetch("/api/politician-portfolios/disclosures", {


### PR DESCRIPTION
## Summary

Adds 10 missing optional parameters to the politicians tool, improving filtering capabilities for politician portfolio and trading data.

## Changes

### New Parameters for `/api/politician-portfolios/{politician_id}` (portfolio action)
- `aggregate_all_portfolios` - Combine data from all portfolios

### New Parameters for `/api/politician-portfolios/recent_trades` (recent_trades action)
- `date` - Filter by specific date (YYYY-MM-DD format)
- `ticker` - Filter by stock ticker symbol
- `politician_id` - Filter by specific politician
- `filter_late_reports` - Exclude late-filed reports
- `disclosure_newer_than` - Filter disclosures after a date
- `disclosure_older_than` - Filter disclosures before a date
- `transaction_newer_than` - Filter transactions after a date
- `transaction_older_than` - Filter transactions before a date

### New Parameters for `/api/politician-portfolios/holders/{ticker}` (holders action)
- `aggregate_all_portfolios` - Combine data from all portfolios

## Implementation Details

- Added new optional fields to the Zod input schema with proper types and descriptions
- Updated the `handlePoliticians` function to pass new parameters to API calls
- Updated tool description to document available parameters for each action
- Uses existing `dateSchema` from shared schemas for date validation (YYYY-MM-DD format)

Closes #27