### PR TITLE
fix(issue-29): Add 7 missing optional parameters to seasonality tool

### DIFF
--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -229,3 +229,13 @@ export const insiderTransactionFiltersSchema = z.object({
 
 /** Delta value for risk reversal skew (10 or 25) */
 export const deltaSchema = z.enum(["10", "25"]).describe("Delta value for risk reversal skew (10 or 25, representing 0.10 or 0.25)")
+
+// ============================================================================
+// Seasonality-specific schemas
+// ============================================================================
+
+/** Seasonality performers order by column */
+export const seasonalityOrderBySchema = z.enum([
+  "month", "positive_closes", "years", "positive_months_perc",
+  "median_change", "avg_change", "max_change", "min_change",
+]).describe("Column to order seasonality results by")

--- a/src/tools/seasonality.ts
+++ b/src/tools/seasonality.ts
@@ -1,6 +1,8 @@
 import { z } from "zod"
 import { uwFetch, formatResponse, encodePath, formatError } from "../client.js"
-import { toJsonSchema, tickerSchema, formatZodError,
+import {
+  toJsonSchema, tickerSchema, formatZodError, limitSchema, orderSchema,
+  seasonalityOrderBySchema,
 } from "../schemas.js"
 
 const seasonalityActions = ["market", "performers", "monthly", "year_month"] as const
@@ -9,6 +11,14 @@ const seasonalityInputSchema = z.object({
   action: z.enum(seasonalityActions).describe("The action to perform"),
   ticker: tickerSchema.optional(),
   month: z.number().min(1).max(12).describe("Month number (1-12)").optional(),
+  // Performers-specific optional parameters
+  min_years: z.number().int().min(1).describe("Minimum years of data required (default: 10)").optional(),
+  ticker_for_sector: tickerSchema.describe("A ticker whose sector will be used to filter results").optional(),
+  s_p_500_nasdaq_only: z.boolean().describe("Only return tickers in S&P 500 or Nasdaq 100").optional(),
+  min_oi: z.number().int().nonnegative("Open interest cannot be negative").describe("Minimum open interest filter").optional(),
+  limit: limitSchema.optional(),
+  order: seasonalityOrderBySchema.optional(),
+  order_direction: orderSchema.optional(),
 })
 
 
@@ -19,6 +29,7 @@ export const seasonalityTool = {
 Available actions:
 - market: Get market-wide seasonality data
 - performers: Get top/bottom performers for a month (month required, 1-12)
+  Optional filters: min_years, ticker_for_sector, s_p_500_nasdaq_only, min_oi, limit, order, order_direction
 - monthly: Get monthly seasonality for a ticker (ticker required)
 - year_month: Get year-month breakdown for a ticker (ticker required)`,
   inputSchema: toJsonSchema(seasonalityInputSchema),
@@ -40,7 +51,10 @@ export async function handleSeasonality(args: Record<string, unknown>): Promise<
     return formatError(`Invalid input: ${formatZodError(parsed.error)}`)
   }
 
-  const { action, ticker, month } = parsed.data
+  const {
+    action, ticker, month,
+    min_years, ticker_for_sector, s_p_500_nasdaq_only, min_oi, limit, order, order_direction,
+  } = parsed.data
 
   switch (action) {
     case "market":
@@ -48,7 +62,15 @@ export async function handleSeasonality(args: Record<string, unknown>): Promise<
 
     case "performers":
       if (month === undefined) return formatError("month is required (1-12)")
-      return formatResponse(await uwFetch(`/api/seasonality/${month}/performers`))
+      return formatResponse(await uwFetch(`/api/seasonality/${month}/performers`, {
+        min_years,
+        ticker_for_sector,
+        s_p_500_nasdaq_only,
+        min_oi,
+        limit,
+        order,
+        order_direction,
+      }))
 
     case "monthly":
       if (!ticker) return formatError("ticker is required")


### PR DESCRIPTION
## Missing Optional Parameters

The following optional API parameters are not being passed in `src/tools/seasonality.ts`.
Adding these would improve filtering and functionality.

### `/api/seasonality/{month}/performers`

- `min_years`
- `ticker_for_sector`
- `s_p_500_nasdaq_only`
- `min_oi`
- `limit`
- `order`
- `order_direction`

---
*Auto-generated by API sync checker*