### PR TITLE
feat(issue-30): add 44 missing optional API parameters

### DIFF
--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -239,3 +239,41 @@ export const seasonalityOrderBySchema = z.enum([
   "month", "positive_closes", "years", "positive_months_perc",
   "median_change", "avg_change", "max_change", "min_change",
 ]).describe("Column to order seasonality results by")
+
+// ============================================================================
+// Pagination and ordering schemas
+// ============================================================================
+
+/** Pagination page number */
+export const pageSchema = z.number()
+  .int("Page must be an integer")
+  .positive("Page must be positive")
+  .describe("Page number for paginated results")
+
+/** IV rank timespan */
+export const timespanSchema = z.string().describe("Timespan for IV rank data")
+
+// ============================================================================
+// Stock option contract filter schemas
+// ============================================================================
+
+export const optionContractFiltersSchema = z.object({
+  vol_greater_oi: z.boolean().describe("Filter for contracts where volume > open interest").optional(),
+  exclude_zero_vol_chains: z.boolean().describe("Exclude chains with zero volume").optional(),
+  exclude_zero_dte: z.boolean().describe("Exclude zero days to expiration contracts").optional(),
+  exclude_zero_oi_chains: z.boolean().describe("Exclude chains with zero open interest").optional(),
+  maybe_otm_only: z.boolean().describe("Filter for out-of-the-money options only").optional(),
+  option_symbol: z.string().describe("Specific option symbol to filter by").optional(),
+})
+
+// ============================================================================
+// Stock flow filter schemas
+// ============================================================================
+
+export const stockFlowFiltersSchema = z.object({
+  is_ask_side: z.boolean().describe("Filter for ask-side trades").optional(),
+  is_bid_side: z.boolean().describe("Filter for bid-side trades").optional(),
+  side: z.string().describe("Filter by trade side").optional(),
+  min_premium: z.number().nonnegative("Premium cannot be negative").describe("Minimum premium filter").optional(),
+  filter: z.string().describe("Filter type for intraday flow").optional(),
+})

--- a/src/tools/stock.ts
+++ b/src/tools/stock.ts
@@ -12,6 +12,12 @@ import {
   timeframeSchema,
   deltaSchema,
   formatZodError,
+  orderSchema,
+  pageSchema,
+  timespanSchema,
+  optionContractFiltersSchema,
+  stockFlowFiltersSchema,
+  dteFilterSchema,
 } from "../schemas.js"
 
 const stockActions = [
@@ -75,7 +81,17 @@ const stockInputSchema = z.object({
   limit: limitSchema.optional(),
   timeframe: timeframeSchema.optional(),
   delta: deltaSchema.optional(),
+  // Pagination and ordering
+  page: pageSchema.optional(),
+  order: orderSchema.optional(),
+  // OHLC parameters
+  end_date: dateSchema.optional().describe("End date for OHLC data in YYYY-MM-DD format"),
+  // IV rank timespan
+  timespan: timespanSchema.optional(),
 })
+  .merge(optionContractFiltersSchema)
+  .merge(stockFlowFiltersSchema)
+  .merge(dteFilterSchema)
 
 
 export const stockTool = {
@@ -84,46 +100,46 @@ export const stockTool = {
 
 Available actions:
 - info: Get stock information (ticker required)
-- ohlc: Get OHLC candles (ticker, candle_size required; date optional)
-- option_chains: Get option chains (ticker required; expiry, min_strike, max_strike optional)
-- option_contracts: Get option contracts (ticker required; expiry, strike, option_type optional)
-- greeks: Get greeks data (ticker required; expiry optional)
-- greek_exposure: Get gamma/delta/vanna exposure (ticker required; date optional)
+- ohlc: Get OHLC candles (ticker, candle_size required; date, timeframe, end_date, limit optional)
+- option_chains: Get option chains (ticker required; date, expiry, min_strike, max_strike optional)
+- option_contracts: Get option contracts (ticker required; expiry, strike, option_type, vol_greater_oi, exclude_zero_vol_chains, exclude_zero_dte, exclude_zero_oi_chains, maybe_otm_only, option_symbol, limit, page optional)
+- greeks: Get greeks data (ticker required; date, expiry optional)
+- greek_exposure: Get gamma/delta/vanna exposure (ticker required; date, timeframe optional)
 - greek_exposure_by_expiry: Get greek exposure by expiry (ticker required; date optional)
 - greek_exposure_by_strike: Get greek exposure by strike (ticker required; date optional)
 - greek_exposure_by_strike_expiry: Get greek exposure by strike and expiry (ticker required; expiry, date optional)
 - greek_flow: Get greek flow (ticker required; date optional)
 - greek_flow_by_expiry: Get greek flow by expiry (ticker, expiry required; date optional)
-- iv_rank: Get IV rank (ticker required; date optional)
-- interpolated_iv: Get interpolated IV (ticker required; expiry optional)
-- max_pain: Get max pain (ticker required; expiry optional)
-- oi_change: Get OI change (ticker required; date optional)
+- iv_rank: Get IV rank (ticker required; date, timespan optional)
+- interpolated_iv: Get interpolated IV (ticker required; date, expiry optional)
+- max_pain: Get max pain (ticker required; date, expiry optional)
+- oi_change: Get OI change (ticker required; date, limit, page, order optional)
 - oi_per_expiry: Get OI per expiry (ticker required; date optional)
 - oi_per_strike: Get OI per strike (ticker required; expiry, date optional)
-- options_volume: Get options volume (ticker required; date optional)
+- options_volume: Get options volume (ticker required; date, limit optional)
 - volume_oi_expiry: Get volume/OI by expiry (ticker required; date optional)
 - atm_chains: Get ATM chains for given expirations (ticker, expirations[] required)
 - expiry_breakdown: Get expiry breakdown (ticker required; date optional)
-- flow_alerts: Get flow alerts for ticker (ticker required; date optional)
+- flow_alerts: Get flow alerts for ticker (ticker required; date, limit, is_ask_side, is_bid_side optional)
 - flow_per_expiry: Get flow per expiry (ticker required; date optional)
-- flow_per_strike: Get flow per strike (ticker required; expiry optional)
-- flow_per_strike_intraday: Get intraday flow per strike (ticker required; expiry, date optional)
-- flow_recent: Get recent flow (ticker required; limit optional)
+- flow_per_strike: Get flow per strike (ticker required; date, expiry optional)
+- flow_per_strike_intraday: Get intraday flow per strike (ticker required; expiry, date, filter optional)
+- flow_recent: Get recent flow (ticker required; limit, side, min_premium optional)
 - net_prem_ticks: Get net premium ticks (ticker required; date optional)
 - nope: Get NOPE data (ticker required; date optional)
 - stock_price_levels: Get stock price levels (ticker required; date optional)
 - stock_volume_price_levels: Get volume price levels (ticker required; date optional)
 - spot_exposures: Get spot exposures (ticker required; date optional)
-- spot_exposures_by_expiry_strike: Get spot exposures by expiry/strike (ticker, expirations required; date optional)
-- spot_exposures_by_strike: Get spot exposures by strike (ticker required; date optional)
-- spot_exposures_expiry_strike: Get spot exposures for specific expiry (ticker, expiry required; date optional)
+- spot_exposures_by_expiry_strike: Get spot exposures by expiry/strike (ticker, expirations required; date, limit, page, min_strike, max_strike, min_dte, max_dte optional)
+- spot_exposures_by_strike: Get spot exposures by strike (ticker required; date, min_strike, max_strike, limit, page optional)
+- spot_exposures_expiry_strike: Get spot exposures for specific expiry (ticker, expiry required; date, min_strike, max_strike optional)
 - historical_risk_reversal_skew: Get risk reversal skew (ticker, expiry, delta required; date, timeframe optional)
-- volatility_realized: Get realized volatility (ticker required; timeframe optional)
-- volatility_stats: Get volatility stats (ticker required)
+- volatility_realized: Get realized volatility (ticker required; date, timeframe optional)
+- volatility_stats: Get volatility stats (ticker required; date optional)
 - volatility_term_structure: Get term structure (ticker required; date optional)
 - stock_state: Get stock state (ticker required; date optional)
 - insider_buy_sells: Get insider buy/sells for stock (ticker required; limit optional)
-- ownership: Get ownership data (ticker required)
+- ownership: Get ownership data (ticker required; limit optional)
 - tickers_by_sector: Get tickers in sector (sector required)
 - ticker_exchanges: Get mapping of all tickers to their exchanges (no params required)`,
   inputSchema: toJsonSchema(stockInputSchema),
@@ -145,7 +161,45 @@ export async function handleStock(args: Record<string, unknown>): Promise<string
     return formatError(`Invalid input: ${formatZodError(parsed.error)}`)
   }
 
-  const { action, ticker, sector, date, expiry, expirations, candle_size, strike, min_strike, max_strike, option_type, limit, timeframe, delta } = parsed.data
+  const {
+    action,
+    ticker,
+    sector,
+    date,
+    expiry,
+    expirations,
+    candle_size,
+    strike,
+    min_strike,
+    max_strike,
+    option_type,
+    limit,
+    timeframe,
+    delta,
+    // Pagination and ordering
+    page,
+    order,
+    // OHLC parameters
+    end_date,
+    // IV rank timespan
+    timespan,
+    // Option contract filters
+    vol_greater_oi,
+    exclude_zero_vol_chains,
+    exclude_zero_dte,
+    exclude_zero_oi_chains,
+    maybe_otm_only,
+    option_symbol,
+    // Flow filters
+    is_ask_side,
+    is_bid_side,
+    side,
+    min_premium,
+    filter,
+    // DTE filters
+    min_dte,
+    max_dte,
+  } = parsed.data
 
   // Encode path parameters once if they exist
   const safeTicker = ticker ? encodePath(ticker) : ""
@@ -160,11 +214,17 @@ export async function handleStock(args: Record<string, unknown>): Promise<string
 
     case "ohlc":
       if (!ticker || !candle_size) return formatError("ticker and candle_size are required")
-      return formatResponse(await uwFetch(`/api/stock/${safeTicker}/ohlc/${safeCandle}`, { date }))
+      return formatResponse(await uwFetch(`/api/stock/${safeTicker}/ohlc/${safeCandle}`, {
+        date,
+        timeframe,
+        end_date,
+        limit,
+      }))
 
     case "option_chains":
       if (!ticker) return formatError("ticker is required")
       return formatResponse(await uwFetch(`/api/stock/${safeTicker}/option-chains`, {
+        date,
         expiry,
         min_strike,
         max_strike,
@@ -176,15 +236,23 @@ export async function handleStock(args: Record<string, unknown>): Promise<string
         expiry,
         strike,
         option_type,
+        vol_greater_oi,
+        exclude_zero_vol_chains,
+        exclude_zero_dte,
+        exclude_zero_oi_chains,
+        maybe_otm_only,
+        option_symbol,
+        limit,
+        page,
       }))
 
     case "greeks":
       if (!ticker) return formatError("ticker is required")
-      return formatResponse(await uwFetch(`/api/stock/${safeTicker}/greeks`, { expiry }))
+      return formatResponse(await uwFetch(`/api/stock/${safeTicker}/greeks`, { date, expiry }))
 
     case "greek_exposure":
       if (!ticker) return formatError("ticker is required")
-      return formatResponse(await uwFetch(`/api/stock/${safeTicker}/greek-exposure`, { date }))
+      return formatResponse(await uwFetch(`/api/stock/${safeTicker}/greek-exposure`, { date, timeframe }))
 
     case "greek_exposure_by_expiry":
       if (!ticker) return formatError("ticker is required")
@@ -211,19 +279,19 @@ export async function handleStock(args: Record<string, unknown>): Promise<string
 
     case "iv_rank":
       if (!ticker) return formatError("ticker is required")
-      return formatResponse(await uwFetch(`/api/stock/${safeTicker}/iv-rank`, { date }))
+      return formatResponse(await uwFetch(`/api/stock/${safeTicker}/iv-rank`, { date, timespan }))
 
     case "interpolated_iv":
       if (!ticker) return formatError("ticker is required")
-      return formatResponse(await uwFetch(`/api/stock/${safeTicker}/interpolated-iv`, { expiry }))
+      return formatResponse(await uwFetch(`/api/stock/${safeTicker}/interpolated-iv`, { date, expiry }))
 
     case "max_pain":
       if (!ticker) return formatError("ticker is required")
-      return formatResponse(await uwFetch(`/api/stock/${safeTicker}/max-pain`, { expiry }))
+      return formatResponse(await uwFetch(`/api/stock/${safeTicker}/max-pain`, { date, expiry }))
 
     case "oi_change":
       if (!ticker) return formatError("ticker is required")
-      return formatResponse(await uwFetch(`/api/stock/${safeTicker}/oi-change`, { date }))
+      return formatResponse(await uwFetch(`/api/stock/${safeTicker}/oi-change`, { date, limit, page, order }))
 
     case "oi_per_expiry":
       if (!ticker) return formatError("ticker is required")
@@ -238,7 +306,7 @@ export async function handleStock(args: Record<string, unknown>): Promise<string
 
     case "options_volume":
       if (!ticker) return formatError("ticker is required")
-      return formatResponse(await uwFetch(`/api/stock/${safeTicker}/options-volume`, { date }))
+      return formatResponse(await uwFetch(`/api/stock/${safeTicker}/options-volume`, { date, limit }))
 
     case "volume_oi_expiry":
       if (!ticker) return formatError("ticker is required")
@@ -255,7 +323,7 @@ export async function handleStock(args: Record<string, unknown>): Promise<string
 
     case "flow_alerts":
       if (!ticker) return formatError("ticker is required")
-      return formatResponse(await uwFetch(`/api/stock/${safeTicker}/flow-alerts`, { date }))
+      return formatResponse(await uwFetch(`/api/stock/${safeTicker}/flow-alerts`, { date, limit, is_ask_side, is_bid_side }))
 
     case "flow_per_expiry":
       if (!ticker) return formatError("ticker is required")
@@ -263,18 +331,19 @@ export async function handleStock(args: Record<string, unknown>): Promise<string
 
     case "flow_per_strike":
       if (!ticker) return formatError("ticker is required")
-      return formatResponse(await uwFetch(`/api/stock/${safeTicker}/flow-per-strike`, { expiry }))
+      return formatResponse(await uwFetch(`/api/stock/${safeTicker}/flow-per-strike`, { date, expiry }))
 
     case "flow_per_strike_intraday":
       if (!ticker) return formatError("ticker is required")
       return formatResponse(await uwFetch(`/api/stock/${safeTicker}/flow-per-strike-intraday`, {
         expiry,
         date,
+        filter,
       }))
 
     case "flow_recent":
       if (!ticker) return formatError("ticker is required")
-      return formatResponse(await uwFetch(`/api/stock/${safeTicker}/flow-recent`, { limit }))
+      return formatResponse(await uwFetch(`/api/stock/${safeTicker}/flow-recent`, { limit, side, min_premium }))
 
     case "net_prem_ticks":
       if (!ticker) return formatError("ticker is required")
@@ -301,15 +370,31 @@ export async function handleStock(args: Record<string, unknown>): Promise<string
       return formatResponse(await uwFetch(`/api/stock/${safeTicker}/spot-exposures/expiry-strike`, {
         "expirations[]": expirations,
         date,
+        limit,
+        page,
+        min_strike,
+        max_strike,
+        min_dte,
+        max_dte,
       }))
 
     case "spot_exposures_by_strike":
       if (!ticker) return formatError("ticker is required")
-      return formatResponse(await uwFetch(`/api/stock/${safeTicker}/spot-exposures/strike`, { date }))
+      return formatResponse(await uwFetch(`/api/stock/${safeTicker}/spot-exposures/strike`, {
+        date,
+        min_strike,
+        max_strike,
+        limit,
+        page,
+      }))
 
     case "spot_exposures_expiry_strike":
       if (!ticker || !expiry) return formatError("ticker and expiry are required")
-      return formatResponse(await uwFetch(`/api/stock/${safeTicker}/spot-exposures/${safeExpiry}/strike`, { date }))
+      return formatResponse(await uwFetch(`/api/stock/${safeTicker}/spot-exposures/${safeExpiry}/strike`, {
+        date,
+        min_strike,
+        max_strike,
+      }))
 
     case "historical_risk_reversal_skew":
       if (!ticker || !expiry || !delta) return formatError("ticker, expiry, and delta are required")
@@ -317,11 +402,11 @@ export async function handleStock(args: Record<string, unknown>): Promise<string
 
     case "volatility_realized":
       if (!ticker) return formatError("ticker is required")
-      return formatResponse(await uwFetch(`/api/stock/${safeTicker}/volatility/realized`, { timeframe }))
+      return formatResponse(await uwFetch(`/api/stock/${safeTicker}/volatility/realized`, { date, timeframe }))
 
     case "volatility_stats":
       if (!ticker) return formatError("ticker is required")
-      return formatResponse(await uwFetch(`/api/stock/${safeTicker}/volatility/stats`))
+      return formatResponse(await uwFetch(`/api/stock/${safeTicker}/volatility/stats`, { date }))
 
     case "volatility_term_structure":
       if (!ticker) return formatError("ticker is required")
@@ -337,7 +422,7 @@ export async function handleStock(args: Record<string, unknown>): Promise<string
 
     case "ownership":
       if (!ticker) return formatError("ticker is required")
-      return formatResponse(await uwFetch(`/api/stock/${safeTicker}/ownership`))
+      return formatResponse(await uwFetch(`/api/stock/${safeTicker}/ownership`, { limit }))
 
     case "tickers_by_sector":
       if (!sector) return formatError("sector is required")


### PR DESCRIPTION
## Summary

Adds all 44 missing optional parameters to the stock tool as identified by the API sync checker. This improves the filtering and functionality available for stock-related API endpoints.

## Changes Made

### New Schema Definitions (`src/schemas.ts`)
- Added `pageSchema` for pagination support
- Added `timespanSchema` for IV rank timespan
- Added `optionContractFiltersSchema` with 6 boolean/string filters for option contracts
- Added `stockFlowFiltersSchema` with 5 flow-related filters

### Updated Stock Tool (`src/tools/stock.ts`)
Extended 21 endpoints with their missing optional parameters:

| Endpoint | Added Parameters |
|----------|-----------------|
| `ohlc` | `date`, `timeframe`, `end_date`, `limit` |
| `option_chains` | `date` |
| `option_contracts` | `vol_greater_oi`, `exclude_zero_vol_chains`, `exclude_zero_dte`, `exclude_zero_oi_chains`, `maybe_otm_only`, `option_symbol`, `limit`, `page` |
| `greeks` | `date` |
| `greek_exposure` | `timeframe` |
| `iv_rank` | `timespan` |
| `interpolated_iv` | `date` |
| `max_pain` | `date` |
| `oi_change` | `limit`, `page`, `order` |
| `options_volume` | `limit` |
| `flow_alerts` | `limit`, `is_ask_side`, `is_bid_side` |
| `flow_per_strike` | `date` |
| `flow_per_strike_intraday` | `filter` |
| `flow_recent` | `side`, `min_premium` |
| `spot_exposures/expiry-strike` | `limit`, `page`, `min_strike`, `max_strike`, `min_dte`, `max_dte` |
| `spot_exposures/strike` | `min_strike`, `max_strike`, `limit`, `page` |
| `spot_exposures/{expiry}/strike` | `min_strike`, `max_strike` |
| `volatility/realized` | `date` |
| `volatility/stats` | `date` |
| `ownership` | `limit` |

## Implementation Details

- Used Zod schema merging pattern (`.merge()`) for clean, reusable filter definitions
- All new parameters are optional and backward-compatible
- Updated tool description to document all new optional parameters
- Reused existing schemas (`dteFilterSchema`, `orderSchema`) where applicable

## Testing

- Build passes (`npm run build`)
- Lint passes (`npm run lint`)
- API sync checker confirms no missing stock.ts parameters from issue list

Closes #30