### PR TITLE
fix(issue-45): Remove unsupported parameters from flow-alerts endpoint

### DIFF
--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -104,8 +104,6 @@ export const flowTradeFiltersSchema = z.object({
   is_floor: z.boolean().describe("Filter for floor trades").optional(),
   is_sweep: z.boolean().describe("Filter for sweep trades").optional(),
   is_multi_leg: z.boolean().describe("Filter for multi-leg trades").optional(),
-  is_unusual: z.boolean().describe("Filter for unusual trades").optional(),
-  is_golden_sweep: z.boolean().describe("Filter for golden sweep trades").optional(),
 })
 
 export const flowAlertsExtendedFiltersSchema = z.object({

--- a/src/tools/flow.ts
+++ b/src/tools/flow.ts
@@ -6,12 +6,9 @@ import {
   dateSchema,
   expirySchema,
   limitSchema,
-  optionTypeSchema,
-  orderSchema,
   flowGroupSchema,
   premiumFilterSchema,
   sizeFilterSchema,
-  oiFilterSchema,
   dteFilterSchema,
   flowTradeFiltersSchema,
   flowAlertsExtendedFiltersSchema,
@@ -28,11 +25,8 @@ const flowInputSchema = z.object({
   expiry: expirySchema.optional(),
   ticker: tickerSchema.describe("Ticker symbol filter").optional(),
   limit: limitSchema.optional(),
-  side: optionTypeSchema.describe("Trade side (call or put)").optional(),
-  order: orderSchema.optional(),
 }).merge(premiumFilterSchema)
   .merge(sizeFilterSchema)
-  .merge(oiFilterSchema)
   .merge(dteFilterSchema)
   .merge(flowTradeFiltersSchema)
   .merge(flowAlertsExtendedFiltersSchema)
@@ -83,17 +77,11 @@ export async function handleFlow(args: Record<string, unknown>): Promise<string>
     max_premium,
     min_size,
     max_size,
-    min_oi,
-    max_oi,
     min_dte,
     max_dte,
     is_floor,
     is_sweep,
     is_multi_leg,
-    is_unusual,
-    is_golden_sweep,
-    side,
-    order,
     // Extended flow alerts filters
     min_volume,
     max_volume,
@@ -144,24 +132,17 @@ export async function handleFlow(args: Record<string, unknown>): Promise<string>
   switch (action) {
     case "flow_alerts":
       return formatResponse(await uwFetch("/api/option-trades/flow-alerts", {
-        date,
         ticker_symbol: ticker,
         limit,
         min_premium,
         max_premium,
         min_size,
         max_size,
-        min_oi,
-        max_oi,
         min_dte,
         max_dte,
         is_floor,
         is_sweep,
         is_multi_leg,
-        is_unusual,
-        is_golden_sweep,
-        side,
-        order,
         // Extended filters
         min_volume,
         max_volume,


### PR DESCRIPTION
## Summary

Removes 8 parameters from the flow tool that are not supported by the `/api/option-trades/flow-alerts` API endpoint according to the OpenAPI spec.

## Changes Made

### Removed Parameters

The following parameters were being passed to the API but are not documented in the spec:

1. **`date`** - Removed from the flow_alerts API call
2. **`min_oi` / `max_oi`** - Removed (API uses `min_open_interest` / `max_open_interest` instead, which were already present)
3. **`is_unusual`** - Removed from `flowTradeFiltersSchema` and flow handler
4. **`is_golden_sweep`** - Removed from `flowTradeFiltersSchema` and flow handler
5. **`side`** - Removed from input schema (API uses `is_call`/`is_put` instead)
6. **`order`** - Removed from input schema

### Files Modified

- `src/tools/flow.ts` - Removed unsupported parameters from input schema, destructuring, and uwFetch call
- `src/schemas.ts` - Removed `is_unusual` and `is_golden_sweep` from `flowTradeFiltersSchema`

## Why

These parameters were identified by the API sync checker as not being documented in the UnusualWhales API spec. Passing unsupported parameters could lead to unexpected behavior or errors.

## Verification

- Build passes successfully
- All remaining parameters align with the documented API spec