### PR TITLE
feat: add idempotentHint annotation to all tools

### DIFF
--- a/src/tools/alerts.ts
+++ b/src/tools/alerts.ts
@@ -26,6 +26,7 @@ Available actions:
   inputSchema: toJsonSchema(alertsInputSchema),
   annotations: {
     readOnlyHint: true,
+    idempotentHint: true,
     openWorldHint: true,
   },
 }

--- a/src/tools/congress.ts
+++ b/src/tools/congress.ts
@@ -24,6 +24,7 @@ Available actions:
   inputSchema: toJsonSchema(congressInputSchema),
   annotations: {
     readOnlyHint: true,
+    idempotentHint: true,
     openWorldHint: true,
   },
 }

--- a/src/tools/darkpool.ts
+++ b/src/tools/darkpool.ts
@@ -37,6 +37,7 @@ Filtering options include premium range, size range, and volume range.`,
   inputSchema: toJsonSchema(darkpoolInputSchema),
   annotations: {
     readOnlyHint: true,
+    idempotentHint: true,
     openWorldHint: true,
   },
 }

--- a/src/tools/earnings.ts
+++ b/src/tools/earnings.ts
@@ -25,6 +25,7 @@ Available actions:
   inputSchema: toJsonSchema(earningsInputSchema),
   annotations: {
     readOnlyHint: true,
+    idempotentHint: true,
     openWorldHint: true,
   },
 }

--- a/src/tools/etf.ts
+++ b/src/tools/etf.ts
@@ -24,6 +24,7 @@ Available actions:
   inputSchema: toJsonSchema(etfInputSchema),
   annotations: {
     readOnlyHint: true,
+    idempotentHint: true,
     openWorldHint: true,
   },
 }

--- a/src/tools/flow.ts
+++ b/src/tools/flow.ts
@@ -50,6 +50,7 @@ Flow alerts filtering options include: ticker, premium range, volume range, OI r
   inputSchema: toJsonSchema(flowInputSchema),
   annotations: {
     readOnlyHint: true,
+    idempotentHint: true,
     openWorldHint: true,
   },
 }

--- a/src/tools/insider.ts
+++ b/src/tools/insider.ts
@@ -38,6 +38,7 @@ Available actions:
   inputSchema: toJsonSchema(insiderInputSchema),
   annotations: {
     readOnlyHint: true,
+    idempotentHint: true,
     openWorldHint: true,
   },
 }

--- a/src/tools/institutions.ts
+++ b/src/tools/institutions.ts
@@ -39,6 +39,7 @@ Available actions:
   inputSchema: toJsonSchema(institutionsInputSchema),
   annotations: {
     readOnlyHint: true,
+    idempotentHint: true,
     openWorldHint: true,
   },
 }

--- a/src/tools/market.ts
+++ b/src/tools/market.ts
@@ -59,6 +59,7 @@ Available actions:
   inputSchema: toJsonSchema(marketInputSchema),
   annotations: {
     readOnlyHint: true,
+    idempotentHint: true,
     openWorldHint: true,
   },
 }

--- a/src/tools/news.ts
+++ b/src/tools/news.ts
@@ -25,6 +25,7 @@ Available actions:
   inputSchema: toJsonSchema(newsInputSchema),
   annotations: {
     readOnlyHint: true,
+    idempotentHint: true,
     openWorldHint: true,
   },
 }

--- a/src/tools/options.ts
+++ b/src/tools/options.ts
@@ -36,6 +36,7 @@ The 'id' parameter is the option contract symbol (e.g., AAPL240119C00150000).`,
   inputSchema: toJsonSchema(optionsInputSchema),
   annotations: {
     readOnlyHint: true,
+    idempotentHint: true,
     openWorldHint: true,
   },
 }

--- a/src/tools/politicians.ts
+++ b/src/tools/politicians.ts
@@ -36,6 +36,7 @@ Available actions:
   inputSchema: toJsonSchema(politiciansInputSchema),
   annotations: {
     readOnlyHint: true,
+    idempotentHint: true,
     openWorldHint: true,
   },
 }

--- a/src/tools/screener.ts
+++ b/src/tools/screener.ts
@@ -60,6 +60,7 @@ Available actions:
   inputSchema: toJsonSchema(screenerInputSchema),
   annotations: {
     readOnlyHint: true,
+    idempotentHint: true,
     openWorldHint: true,
   },
 }

--- a/src/tools/seasonality.ts
+++ b/src/tools/seasonality.ts
@@ -35,6 +35,7 @@ Available actions:
   inputSchema: toJsonSchema(seasonalityInputSchema),
   annotations: {
     readOnlyHint: true,
+    idempotentHint: true,
     openWorldHint: true,
   },
 }

--- a/src/tools/shorts.ts
+++ b/src/tools/shorts.ts
@@ -24,6 +24,7 @@ Available actions:
   inputSchema: toJsonSchema(shortsInputSchema),
   annotations: {
     readOnlyHint: true,
+    idempotentHint: true,
     openWorldHint: true,
   },
 }

--- a/src/tools/stock.ts
+++ b/src/tools/stock.ts
@@ -145,6 +145,7 @@ Available actions:
   inputSchema: toJsonSchema(stockInputSchema),
   annotations: {
     readOnlyHint: true,
+    idempotentHint: true,
     openWorldHint: true,
   },
 }


### PR DESCRIPTION
## Summary

Added `idempotentHint: true` annotation to all 16 tool files in the MCP server.

## Changes

All tools now include the `idempotentHint` annotation in their tool definitions:

```typescript
annotations: {
  readOnlyHint: true,
  idempotentHint: true,  // Added
  openWorldHint: true,
}
```

### Files Updated
- `src/tools/alerts.ts`
- `src/tools/congress.ts`
- `src/tools/darkpool.ts`
- `src/tools/earnings.ts`
- `src/tools/etf.ts`
- `src/tools/flow.ts`
- `src/tools/insider.ts`
- `src/tools/institutions.ts`
- `src/tools/market.ts`
- `src/tools/news.ts`
- `src/tools/options.ts`
- `src/tools/politicians.ts`
- `src/tools/screener.ts`
- `src/tools/seasonality.ts`
- `src/tools/shorts.ts`
- `src/tools/stock.ts`

## Why This Matters

The `idempotentHint` tells MCP clients that calling these tools multiple times with the same arguments produces the same result. This is appropriate because all tools are read-only GET requests to the UnusualWhales API. This enables:

- **Safe retries** - Clients can retry failed requests without side effects
- **Response caching** - Clients can cache responses for identical requests
- **Better optimization** - Clients can make smarter decisions about request deduplication