### PR TITLE
feat(issue-14): Expose API documentation as MCP Resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ An MCP server that provides access to the [Unusual Whales](https://unusualwhales
 
 ## Features
 
+### Tools
+
 | Tool | Description |
 |------|-------------|
 | **Stock** | Options chains, Greeks, IV rank, OHLC candles, max pain, open interest, flow alerts, spot exposures, volatility analysis |
@@ -22,6 +24,17 @@ An MCP server that provides access to the [Unusual Whales](https://unusualwhales
 | **Screener** | Stock screener, options contract screener, analyst ratings screener |
 | **News** | Market news headlines with ticker filter |
 | **Alerts** | User alert configurations and triggered alerts |
+
+### Resources
+
+The server exposes documentation resources that AI assistants can access:
+
+| Resource | URI | Description |
+|----------|-----|-------------|
+| **API Reference** | `docs://api-reference` | Complete reference documentation for all available tools with input schemas and annotations |
+| **Tools Summary** | `docs://tools-summary` | JSON summary of available tools with their actions and required parameters |
+
+AI assistants can request these resources when they need information about available functionality or tool usage.
 
 ## Prerequisites
 

--- a/src/resources/index.ts
+++ b/src/resources/index.ts
@@ -1,0 +1,126 @@
+import type { ToolDefinition } from "../tools/index.js"
+
+export type ResourceHandler = () => Promise<string>
+
+export interface ResourceDefinition {
+  uri: string
+  name: string
+  description: string
+  mimeType: string
+}
+
+interface ResourceRegistration {
+  resource: ResourceDefinition
+  handler: ResourceHandler
+}
+
+/**
+ * Generate API reference documentation from tool definitions.
+ */
+export function generateApiReference(tools: ToolDefinition[]): string {
+  const sections = tools.map((tool) => {
+    const lines = [
+      `## ${tool.name}`,
+      "",
+      tool.description,
+      "",
+      "### Input Schema",
+      "",
+      "```json",
+      JSON.stringify(tool.inputSchema, null, 2),
+      "```",
+      "",
+    ]
+
+    if (tool.annotations) {
+      lines.push("### Annotations", "")
+      const annotations = []
+      if (tool.annotations.readOnlyHint) annotations.push("- Read-only operation")
+      if (tool.annotations.idempotentHint) annotations.push("- Idempotent operation")
+      if (tool.annotations.openWorldHint) annotations.push("- Open world (may return unexpected fields)")
+      if (tool.annotations.destructiveHint) annotations.push("- Destructive operation")
+      lines.push(...annotations, "")
+    }
+
+    return lines.join("\n")
+  })
+
+  return [
+    "# Unusual Whales API Reference",
+    "",
+    "This document provides complete reference documentation for all available Unusual Whales API tools.",
+    "",
+    "## Available Tools",
+    "",
+    tools.map((t, i) => `${i + 1}. [${t.name}](#${t.name.replace(/_/g, "")})`).join("\n"),
+    "",
+    ...sections,
+  ].join("\n")
+}
+
+/**
+ * Generate tools summary as JSON.
+ */
+export function generateToolsSummary(tools: ToolDefinition[]): string {
+  const summary = {
+    totalTools: tools.length,
+    tools: tools.map((tool) => ({
+      name: tool.name,
+      description: tool.description.split("\n")[0], // First line only
+      requiredParameters: tool.inputSchema.required || [],
+      annotations: tool.annotations || {},
+    })),
+  }
+
+  return JSON.stringify(summary, null, 2)
+}
+
+/**
+ * Create resource handler for API reference.
+ */
+function createApiReferenceHandler(tools: ToolDefinition[]): ResourceHandler {
+  return async () => generateApiReference(tools)
+}
+
+/**
+ * Create resource handler for tools summary.
+ */
+function createToolsSummaryHandler(tools: ToolDefinition[]): ResourceHandler {
+  return async () => generateToolsSummary(tools)
+}
+
+/**
+ * Initialize resources with the given tools.
+ */
+export function initializeResources(tools: ToolDefinition[]): {
+  resources: ResourceDefinition[]
+  handlers: Record<string, ResourceHandler>
+} {
+  const resourceRegistrations: ResourceRegistration[] = [
+    {
+      resource: {
+        uri: "docs://api-reference",
+        name: "API Reference",
+        description: "Complete reference documentation for all Unusual Whales API endpoints and tools",
+        mimeType: "text/markdown",
+      },
+      handler: createApiReferenceHandler(tools),
+    },
+    {
+      resource: {
+        uri: "docs://tools-summary",
+        name: "Tools Summary",
+        description: "Summary of available tools with their actions and parameters",
+        mimeType: "application/json",
+      },
+      handler: createToolsSummaryHandler(tools),
+    },
+  ]
+
+  return {
+    resources: resourceRegistrations.map((reg) => reg.resource),
+    handlers: Object.fromEntries(
+      resourceRegistrations.map((reg) => [reg.resource.uri, reg.handler]),
+    ),
+  }
+}

--- a/tests/unit/resources/index.test.ts
+++ b/tests/unit/resources/index.test.ts
@@ -1,0 +1,237 @@
+import { describe, it, expect } from "vitest"
+import {
+  generateApiReference,
+  generateToolsSummary,
+  initializeResources,
+} from "../../../src/resources/index.js"
+import type { ToolDefinition } from "../../../src/tools/index.js"
+
+describe("generateApiReference", () => {
+  it("generates markdown documentation for tools", () => {
+    const tools: ToolDefinition[] = [
+      {
+        name: "test_tool",
+        description: "A test tool\nWith multiple lines",
+        inputSchema: {
+          type: "object",
+          properties: {
+            action: { type: "string" },
+          },
+          required: ["action"],
+        },
+        annotations: {
+          readOnlyHint: true,
+          idempotentHint: true,
+        },
+      },
+    ]
+
+    const result = generateApiReference(tools)
+
+    expect(result).toContain("# Unusual Whales API Reference")
+    expect(result).toContain("## test_tool")
+    expect(result).toContain("A test tool")
+    expect(result).toContain("### Input Schema")
+    expect(result).toContain("### Annotations")
+    expect(result).toContain("- Read-only operation")
+    expect(result).toContain("- Idempotent operation")
+  })
+
+  it("handles tools without annotations", () => {
+    const tools: ToolDefinition[] = [
+      {
+        name: "simple_tool",
+        description: "Simple tool",
+        inputSchema: {
+          type: "object",
+          properties: {},
+          required: [],
+        },
+      },
+    ]
+
+    const result = generateApiReference(tools)
+
+    expect(result).toContain("## simple_tool")
+    expect(result).not.toContain("### Annotations")
+  })
+
+  it("generates table of contents", () => {
+    const tools: ToolDefinition[] = [
+      {
+        name: "tool_one",
+        description: "First tool",
+        inputSchema: {
+          type: "object",
+          properties: {},
+          required: [],
+        },
+      },
+      {
+        name: "tool_two",
+        description: "Second tool",
+        inputSchema: {
+          type: "object",
+          properties: {},
+          required: [],
+        },
+      },
+    ]
+
+    const result = generateApiReference(tools)
+
+    expect(result).toContain("## Available Tools")
+    expect(result).toContain("1. [tool_one](#toolone)")
+    expect(result).toContain("2. [tool_two](#tooltwo)")
+  })
+})
+
+describe("generateToolsSummary", () => {
+  it("generates JSON summary of tools", () => {
+    const tools: ToolDefinition[] = [
+      {
+        name: "test_tool",
+        description: "A test tool\nWith multiple lines",
+        inputSchema: {
+          type: "object",
+          properties: {
+            action: { type: "string" },
+          },
+          required: ["action"],
+        },
+        annotations: {
+          readOnlyHint: true,
+        },
+      },
+    ]
+
+    const result = generateToolsSummary(tools)
+    const parsed = JSON.parse(result)
+
+    expect(parsed.totalTools).toBe(1)
+    expect(parsed.tools).toHaveLength(1)
+    expect(parsed.tools[0].name).toBe("test_tool")
+    expect(parsed.tools[0].description).toBe("A test tool")
+    expect(parsed.tools[0].requiredParameters).toEqual(["action"])
+    expect(parsed.tools[0].annotations).toEqual({ readOnlyHint: true })
+  })
+
+  it("handles multiple tools", () => {
+    const tools: ToolDefinition[] = [
+      {
+        name: "tool_one",
+        description: "First tool",
+        inputSchema: {
+          type: "object",
+          properties: {},
+          required: [],
+        },
+      },
+      {
+        name: "tool_two",
+        description: "Second tool",
+        inputSchema: {
+          type: "object",
+          properties: {},
+          required: ["param"],
+        },
+      },
+    ]
+
+    const result = generateToolsSummary(tools)
+    const parsed = JSON.parse(result)
+
+    expect(parsed.totalTools).toBe(2)
+    expect(parsed.tools).toHaveLength(2)
+    expect(parsed.tools[0].name).toBe("tool_one")
+    expect(parsed.tools[1].name).toBe("tool_two")
+    expect(parsed.tools[1].requiredParameters).toEqual(["param"])
+  })
+
+  it("uses only first line of description", () => {
+    const tools: ToolDefinition[] = [
+      {
+        name: "test_tool",
+        description: "First line\nSecond line\nThird line",
+        inputSchema: {
+          type: "object",
+          properties: {},
+          required: [],
+        },
+      },
+    ]
+
+    const result = generateToolsSummary(tools)
+    const parsed = JSON.parse(result)
+
+    expect(parsed.tools[0].description).toBe("First line")
+  })
+})
+
+describe("initializeResources", () => {
+  it("creates resource definitions and handlers", () => {
+    const tools: ToolDefinition[] = [
+      {
+        name: "test_tool",
+        description: "A test tool",
+        inputSchema: {
+          type: "object",
+          properties: {},
+          required: [],
+        },
+      },
+    ]
+
+    const { resources, handlers } = initializeResources(tools)
+
+    expect(resources).toHaveLength(2)
+    expect(Object.keys(handlers)).toHaveLength(2)
+  })
+
+  it("creates API reference resource", () => {
+    const tools: ToolDefinition[] = []
+    const { resources, handlers } = initializeResources(tools)
+
+    const apiRefResource = resources.find((r) => r.uri === "docs://api-reference")
+    expect(apiRefResource).toBeDefined()
+    expect(apiRefResource?.name).toBe("API Reference")
+    expect(apiRefResource?.mimeType).toBe("text/markdown")
+    expect(handlers["docs://api-reference"]).toBeDefined()
+  })
+
+  it("creates tools summary resource", () => {
+    const tools: ToolDefinition[] = []
+    const { resources, handlers } = initializeResources(tools)
+
+    const summaryResource = resources.find((r) => r.uri === "docs://tools-summary")
+    expect(summaryResource).toBeDefined()
+    expect(summaryResource?.name).toBe("Tools Summary")
+    expect(summaryResource?.mimeType).toBe("application/json")
+    expect(handlers["docs://tools-summary"]).toBeDefined()
+  })
+
+  it("handlers return correct content", async () => {
+    const tools: ToolDefinition[] = [
+      {
+        name: "test_tool",
+        description: "A test tool",
+        inputSchema: {
+          type: "object",
+          properties: {},
+          required: [],
+        },
+      },
+    ]
+
+    const { handlers } = initializeResources(tools)
+
+    const apiRefContent = await handlers["docs://api-reference"]()
+    expect(apiRefContent).toContain("# Unusual Whales API Reference")
+    expect(apiRefContent).toContain("## test_tool")
+
+    const summaryContent = await handlers["docs://tools-summary"]()
+    const parsed = JSON.parse(summaryContent)
+    expect(parsed.totalTools).toBe(1)
+    expect(parsed.tools[0].name).toBe("test_tool")
+  })
+})


### PR DESCRIPTION
## Summary
Add MCP Resources to expose API documentation and available endpoints.

## Current State
Only tools are exposed - no resources or prompts.

## Proposed Resources

### 1. API Reference
```typescript
server.registerResource(
  "api-reference",
  "docs://api-reference",
  {
    description: "Unusual Whales API endpoint reference",
    mimeType: "text/markdown"
  },
  async () => ({
    contents: [{
      uri: "docs://api-reference",
      text: generateApiDocs() // Markdown of all endpoints
    }]
  })
)
```

### 2. Available Tools Summary
```typescript
server.registerResource(
  "tools-summary",
  "docs://tools",
  {
    description: "Summary of available tools and their actions",
    mimeType: "application/json"
  },
  async () => ({
    contents: [{
      uri: "docs://tools",
      text: JSON.stringify(toolSummary)
    }]
  })
)
```

## Use Cases
- LLM can request documentation when unsure about tool usage
- Users can browse available functionality
- IDE integrations can display help

## Complexity
Medium - need to generate/maintain documentation content.