### PR TITLE
feat: add order and order_direction parameters to institutions activity endpoint

### DIFF
--- a/src/tools/institutions.ts
+++ b/src/tools/institutions.ts
@@ -108,6 +108,8 @@ export async function handleInstitutions(args: Record<string, unknown>): Promise
       if (!name) return formatError("name is required")
       return formatResponse(await uwFetch(`/api/institution/${encodePath(name)}/activity`, {
         date,
+        order,
+        order_direction,
         limit,
         page,
       }))


### PR DESCRIPTION
## Summary

Added two missing optional parameters to the `/api/institution/{name}/activity` endpoint in `src/tools/institutions.ts`:
- `order` - allows ordering results by a specific field
- `order_direction` - allows specifying sort direction (asc or desc)

## Changes Made

- Updated the `activity` action handler to pass `order` and `order_direction` parameters to the API call
- These parameters were already defined in the input schema but weren't being passed through to the actual API request

## Implementation Details

The parameters are optional and follow the same pattern used by other endpoints in the institutions tool (like `holdings`, `ownership`, and `latest_filings`). This change improves filtering and sorting capabilities for institutional activity data.

## Reference

[API Documentation](https://api.unusualwhales.com/docs#/operations/PublicApi.InstitutionController.activity)