### PR TITLE
fix: #76 - remove deprecated flow-alerts endpoint from stock tool

### DIFF
--- a/src/tools/stock.ts
+++ b/src/tools/stock.ts
@@ -43,7 +43,6 @@ const stockActions = [
   "volume_oi_expiry",
   "atm_chains",
   "expiry_breakdown",
-  "flow_alerts",
   "flow_per_expiry",
   "flow_per_strike",
   "flow_per_strike_intraday",
@@ -121,7 +120,6 @@ Available actions:
 - volume_oi_expiry: Get volume/OI by expiry (ticker required; date optional)
 - atm_chains: Get ATM chains for given expirations (ticker, expirations[] required)
 - expiry_breakdown: Get expiry breakdown (ticker required; date optional)
-- flow_alerts: Get flow alerts for ticker (ticker required; limit, is_ask_side, is_bid_side optional)
 - flow_per_expiry: Get flow per expiry (ticker required)
 - flow_per_strike: Get flow per strike (ticker required; date optional)
 - flow_per_strike_intraday: Get intraday flow per strike (ticker required; date, filter optional)
@@ -319,10 +317,6 @@ export async function handleStock(args: Record<string, unknown>): Promise<{ text
     case "expiry_breakdown":
       if (!ticker) return { text: formatError("ticker is required") }
       return formatStructuredResponse(await uwFetch(`/api/stock/${safeTicker}/expiry-breakdown`, { date }))
-
-    case "flow_alerts":
-      if (!ticker) return { text: formatError("ticker is required") }
-      return formatStructuredResponse(await uwFetch(`/api/stock/${safeTicker}/flow-alerts`, { limit, is_ask_side, is_bid_side }))
 
     case "flow_per_expiry":
       if (!ticker) return { text: formatError("ticker is required") }

--- a/tests/unit/tools/stock.test.ts
+++ b/tests/unit/tools/stock.test.ts
@@ -294,22 +294,6 @@ describe("handleStock", () => {
     })
   })
 
-  describe("flow_alerts action", () => {
-    it("calls uwFetch with filter params", async () => {
-      await handleStock({
-        action: "flow_alerts",
-        ticker: "AAPL",
-        limit: 50,
-        is_ask_side: true,
-      })
-      expect(mockUwFetch).toHaveBeenCalledWith("/api/stock/AAPL/flow-alerts", {
-        limit: 50,
-        is_ask_side: true,
-        is_bid_side: undefined,
-      })
-    })
-  })
-
   describe("option_contracts action", () => {
     it("passes filter options correctly", async () => {
       await handleStock({


### PR DESCRIPTION
## Summary

Removed the deprecated `/api/stock/{ticker}/flow-alerts` endpoint from the stock tool to prevent breaking changes when the API removes this endpoint.

## Changes Made

- **Removed `flow_alerts` action** from the stock tool (`src/tools/stock.ts`)
  - Removed from action enum (line 46)
  - Removed from tool description/documentation (line 124)
  - Removed case handler from switch statement (lines 323-325)
- **Updated tests** to remove the deprecated endpoint test case (`tests/unit/tools/stock.test.ts`)

## Why These Changes

The `/api/stock/{ticker}/flow-alerts` endpoint has been deprecated by UnusualWhales API and will be removed. The functionality has been migrated to a superior endpoint at `/api/option-trades/flow-alerts` which is already implemented in the `uw_flow` tool with significantly more filtering capabilities.

## Migration Path

Users previously calling flow alerts through the stock tool can now use the flow tool instead:

**Before:**
```javascript
{
  tool: "uw_stock",
  action: "flow_alerts",
  ticker: "AAPL",
  limit: 50,
  is_ask_side: true
}
```

**After:**
```javascript
{
  tool: "uw_flow",
  action: "flow_alerts",
  ticker_symbol: "AAPL",
  limit: 50,
  is_ask_side: true
}
```

The new endpoint provides additional filtering options including volume ranges, open interest ranges, moneyness filters, IV change filters, and many more advanced options.

## Testing

- ✅ All 544 tests pass
- ✅ Build completes successfully with no errors