### PR TITLE
feat: implement lit-flow endpoints for exchange trades

### DIFF
--- a/src/tools/flow.ts
+++ b/src/tools/flow.ts
@@ -9,6 +9,7 @@ import {
   flowGroupSchema,
   premiumFilterSchema,
   sizeFilterSchema,
+  volumeFilterSchema,
   dteFilterSchema,
   flowTradeFiltersSchema,
   flowAlertsExtendedFiltersSchema,
@@ -17,17 +18,21 @@ import {
   flowOutputSchema,
 } from "../schemas/index.js"
 
-const flowActions = ["flow_alerts", "full_tape", "net_flow_expiry", "group_greek_flow", "group_greek_flow_expiry"] as const
+const flowActions = ["flow_alerts", "full_tape", "net_flow_expiry", "group_greek_flow", "group_greek_flow_expiry", "lit_flow_recent", "lit_flow_ticker"] as const
 
 const flowInputSchema = z.object({
   action: z.enum(flowActions).describe("The action to perform"),
   date: dateSchema.optional(),
   flow_group: flowGroupSchema.optional(),
   expiry: expirySchema.optional(),
+  ticker: tickerSchema.describe("Ticker symbol (required for lit_flow_ticker action)").optional(),
   ticker_symbol: z.string().describe("Comma-separated list of ticker symbols to filter by. Prefix with '-' to exclude tickers (e.g., 'AAPL,INTC' or '-TSLA,NVDA')").optional(),
   limit: limitSchema.optional(),
+  newer_than: z.string().describe("Filter trades newer than timestamp (for lit_flow_ticker)").optional(),
+  older_than: z.string().describe("Filter trades older than timestamp (for lit_flow_ticker)").optional(),
 }).merge(premiumFilterSchema)
   .merge(sizeFilterSchema)
+  .merge(volumeFilterSchema)
   .merge(dteFilterSchema)
   .merge(flowTradeFiltersSchema)
   .merge(flowAlertsExtendedFiltersSchema)
@@ -36,7 +41,7 @@ const flowInputSchema = z.object({
 
 export const flowTool = {
   name: "uw_flow",
-  description: `Access UnusualWhales options flow data including flow alerts, full tape, net flow, and group flow.
+  description: `Access UnusualWhales options flow data including flow alerts, full tape, net flow, group flow, and lit exchange flow.
 
 Available actions:
 - flow_alerts: Get flow alerts with extensive filtering options
@@ -44,10 +49,13 @@ Available actions:
 - net_flow_expiry: Get net flow by expiry date (date optional)
 - group_greek_flow: Get greek flow (delta & vega) for a flow group (flow_group required; date optional)
 - group_greek_flow_expiry: Get greek flow by expiry for a flow group (flow_group, expiry required; date optional)
+- lit_flow_recent: Get recent lit exchange trades across the market
+- lit_flow_ticker: Get lit exchange trades for a specific ticker (ticker required)
 
 Flow groups: airline, bank, basic materials, china, communication services, consumer cyclical, consumer defensive, crypto, cyber, energy, financial services, gas, gold, healthcare, industrials, mag7, oil, real estate, refiners, reit, semi, silver, technology, uranium, utilities
 
-Flow alerts filtering options include: ticker, premium range, volume range, OI range, DTE range, and more.`,
+Flow alerts filtering options include: ticker, premium range, volume range, OI range, DTE range, and more.
+Lit flow filtering options include: premium range, size range, volume range, and timestamp filters.`,
   inputSchema: toJsonSchema(flowInputSchema),
   zodInputSchema: flowInputSchema,
   outputSchema: toJsonSchema(flowOutputSchema),
@@ -75,6 +83,7 @@ export async function handleFlow(args: Record<string, unknown>): Promise<{ text:
     date,
     flow_group,
     expiry,
+    ticker,
     ticker_symbol,
     limit,
     min_premium,
@@ -204,6 +213,33 @@ export async function handleFlow(args: Record<string, unknown>): Promise<{ text:
     case "group_greek_flow_expiry":
       if (!flow_group || !expiry) return { text: formatError("flow_group and expiry are required") }
       return formatStructuredResponse(await uwFetch(`/api/group-flow/${encodePath(flow_group)}/greek-flow/${encodePath(expiry)}`, { date }))
+
+    case "lit_flow_recent":
+      return formatStructuredResponse(await uwFetch("/api/lit-flow/recent", {
+        date,
+        limit,
+        min_premium,
+        max_premium,
+        min_size,
+        max_size,
+        min_volume,
+        max_volume,
+      }))
+
+    case "lit_flow_ticker":
+      if (!ticker) return { text: formatError("ticker is required") }
+      return formatStructuredResponse(await uwFetch(`/api/lit-flow/${encodePath(ticker)}`, {
+        date,
+        limit,
+        min_premium,
+        max_premium,
+        min_size,
+        max_size,
+        min_volume,
+        max_volume,
+        newer_than,
+        older_than,
+      }))
 
     default:
       return { text: formatError(`Unknown action: ${action}`) }

--- a/tests/unit/tools/flow.test.ts
+++ b/tests/unit/tools/flow.test.ts
@@ -201,4 +201,76 @@ describe("handleFlow", () => {
       })
     })
   })
+
+  describe("lit_flow_recent action", () => {
+    it("calls uwFetch with correct endpoint", async () => {
+      await handleFlow({ action: "lit_flow_recent" })
+      expect(mockUwFetch).toHaveBeenCalledWith("/api/lit-flow/recent", expect.any(Object))
+    })
+
+    it("passes filter parameters", async () => {
+      await handleFlow({
+        action: "lit_flow_recent",
+        date: "2024-01-15",
+        limit: 100,
+        min_premium: 10000,
+        max_premium: 1000000,
+        min_size: 100,
+        max_size: 10000,
+        min_volume: 1000,
+        max_volume: 100000,
+      })
+      expect(mockUwFetch).toHaveBeenCalledWith("/api/lit-flow/recent", expect.objectContaining({
+        date: "2024-01-15",
+        limit: 100,
+        min_premium: 10000,
+        max_premium: 1000000,
+        min_size: 100,
+        max_size: 10000,
+        min_volume: 1000,
+        max_volume: 100000,
+      }))
+    })
+  })
+
+  describe("lit_flow_ticker action", () => {
+    it("returns error when ticker is missing", async () => {
+      const result = await handleFlow({ action: "lit_flow_ticker" })
+      expect(result.text).toContain("ticker is required")
+    })
+
+    it("calls uwFetch with correct endpoint", async () => {
+      await handleFlow({ action: "lit_flow_ticker", ticker: "AAPL" })
+      expect(mockUwFetch).toHaveBeenCalledWith("/api/lit-flow/AAPL", expect.any(Object))
+    })
+
+    it("passes filter parameters", async () => {
+      await handleFlow({
+        action: "lit_flow_ticker",
+        ticker: "TSLA",
+        date: "2024-01-15",
+        limit: 200,
+        min_premium: 5000,
+        max_premium: 500000,
+        min_size: 50,
+        max_size: 5000,
+        min_volume: 500,
+        max_volume: 50000,
+        newer_than: "2024-01-15T10:00:00Z",
+        older_than: "2024-01-15T16:00:00Z",
+      })
+      expect(mockUwFetch).toHaveBeenCalledWith("/api/lit-flow/TSLA", expect.objectContaining({
+        date: "2024-01-15",
+        limit: 200,
+        min_premium: 5000,
+        max_premium: 500000,
+        min_size: 50,
+        max_size: 5000,
+        min_volume: 500,
+        max_volume: 50000,
+        newer_than: "2024-01-15T10:00:00Z",
+        older_than: "2024-01-15T16:00:00Z",
+      }))
+    })
+  })
 })


### PR DESCRIPTION
## Summary

Implemented two new endpoints for accessing lit exchange trade data in the Unusual Whales MCP:
- `/api/lit-flow/recent` - Get recent lit exchange trades across the market
- `/api/lit-flow/{ticker}` - Get lit exchange trades for a specific ticker

## Changes Made

### Updated `src/tools/flow.ts`
- Added `lit_flow_recent` and `lit_flow_ticker` actions to the existing flow tool
- Imported `volumeFilterSchema` to support volume-based filtering
- Extended input schema with:
  - `ticker` parameter (required for ticker-specific queries)
  - `newer_than` and `older_than` timestamp filters
- Merged volume filter schema with existing filter schemas
- Updated tool description to document the new lit-flow actions
- Implemented handler logic for both endpoints with full filter support

### Updated `tests/unit/tools/flow.test.ts`
- Added comprehensive test coverage for `lit_flow_recent` action:
  - Endpoint verification
  - Parameter passing validation
- Added comprehensive test coverage for `lit_flow_ticker` action:
  - Required parameter validation
  - Endpoint and path parameter verification
  - Full filter parameter testing including timestamp filters

## Filter Support

Both endpoints support comprehensive filtering options:
- Date filtering: `date`
- Result limiting: `limit` (100 default/200 max for recent, 500 default/max for ticker)
- Premium range: `min_premium`, `max_premium`
- Size range: `min_size`, `max_size`
- Volume range: `min_volume`, `max_volume`
- Timestamp range (ticker only): `newer_than`, `older_than`

## Implementation Details

The implementation follows established patterns from the darkpool tool, ensuring consistency across the codebase. The lit-flow actions are integrated into the existing `uw_flow` tool rather than creating a separate tool, keeping related flow functionality consolidated.

All tests pass (24/24) and the build succeeds with no type errors.