### PR TITLE
fix: filter deprecated endpoints from missing endpoints detection

### DIFF
--- a/scripts/check-api-sync.js
+++ b/scripts/check-api-sync.js
@@ -830,8 +830,14 @@ function compareAll(specEndpoints, implEndpoints, schemaEnums, implSchemas, sche
   }
 
   // Find missing endpoints (in spec but not implemented)
+  // Skip deprecated endpoints - we don't want to implement them
   for (const [normalized, specEp] of normalizedSpecMap) {
     if (!normalizedImplMap.has(normalized)) {
+      const specParams = specEndpoints[specEp]
+      // Skip if endpoint is deprecated
+      if (specParams.deprecated) {
+        continue
+      }
       results.missingEndpoints.push({
         endpoint: specEp,
         operationId: specEndpoints[specEp].operationId,


### PR DESCRIPTION
## Summary

Fixed the API sync checker script to correctly handle deprecated endpoints. Previously, the script was flagging deprecated endpoints as "missing" and creating GitHub issues to implement them, which doesn't make sense since these endpoints are marked for removal.

## Changes Made

Modified `scripts/check-api-sync.js` to add a deprecation check when building the missing endpoints list:
- Added logic to skip endpoints marked as `deprecated` in the OpenAPI spec
- Deprecated endpoints are now only reported in the "DEPRECATED Endpoints Still Implemented" section (for endpoints that exist but should be migrated away from)
- No longer creates "missing endpoint" issues for deprecated endpoints

## Problem Solved

The script was detecting `/api/stock/{ticker}/flow-alerts` and similar deprecated endpoints as "missing" and creating issues to implement them, even though they were recently removed because they're deprecated in the API spec. This created a confusing cycle where the script would ask us to implement endpoints that should actually be avoided.

## Implementation Details

The fix adds a simple check in the missing endpoints detection loop (lines 832-846):
```javascript
// Skip if endpoint is deprecated
if (specParams.deprecated) {
  continue
}
```

This ensures that deprecated endpoints are filtered out before issues are created, preventing unnecessary work on endpoints that are being phased out.