### PR TITLE
fix: add default value of 500 to limit parameter in insider transactions

### DIFF
--- a/src/tools/insider.ts
+++ b/src/tools/insider.ts
@@ -9,7 +9,7 @@ const insiderInputSchema = z.object({
   ticker: tickerSchema.optional().describe("Single stock ticker symbol for ticker_flow and insiders actions"),
   ticker_symbol: z.string().optional().describe("Comma-separated list of ticker symbols for transactions action (e.g., AAPL,INTC). Prefix with - to exclude."),
   sector: z.string().describe("Market sector").optional(),
-  limit: limitSchema.optional(),
+  limit: limitSchema.default(500).optional(),
   page: z.number().describe("Page number for pagination").optional(),
   min_value: z.number().describe("Minimum transaction value").optional(),
   max_value: z.number().describe("Maximum transaction value").optional(),


### PR DESCRIPTION
## Summary
- Fixed default value mismatch for the `limit` parameter in `/api/insider/transactions`
- Added `.default(500)` to the limit parameter in the insider tool schema to match the API specification

## Changes
- Updated `src/tools/insider.ts` line 12 to add default value of 500 to the limit parameter

## Resolves
Fixes #138

## Test Plan
- [x] Build passes successfully
- [x] Schema now includes default value matching API spec