### PR TITLE
fix: add numeric constraints to congress tool limit parameter

### DIFF
--- a/src/tools/congress.ts
+++ b/src/tools/congress.ts
@@ -9,7 +9,7 @@ const congressInputSchema = z.object({
   name: z.string().describe("Congress member name (for congress_trader action)").optional(),
   ticker: tickerSchema.optional(),
   date: dateSchema.optional(),
-  limit: limitSchema.describe("Maximum number of results (default 100, max 200)").optional(),
+  limit: limitSchema.min(1).max(200).default(100).describe("Maximum number of results (default 100, max 200)").optional(),
 })
 
 


### PR DESCRIPTION
## Summary

Fixed 3 numeric constraint mismatches in the congress tool's `limit` parameter to align with the API specification requirements.

## Changes Made

Updated `src/tools/congress.ts` to add proper numeric constraints to the `limit` parameter:

- Added `.min(1)` constraint to enforce minimum value of 1
- Added `.max(200)` constraint to enforce maximum value of 200
- Added `.default(100)` to set default value to 100

**Before:**
```typescript
limit: limitSchema.describe("Maximum number of results (default 100, max 200)").optional()
```

**After:**
```typescript
limit: limitSchema.min(1).max(200).default(100).describe("Maximum number of results (default 100, max 200)").optional()
```

## Why These Changes Were Made

The API specification defines all three congress endpoints (`recent_trades`, `late_reports`, and `congress_trader`) with the "Default 100 Max 200 Min 1" constraint schema. The implementation was only documenting these constraints in the description string, but not enforcing them programmatically through Zod validation.

This fix ensures that:
- Invalid values outside the 1-200 range are rejected at validation time
- The default value of 100 is automatically applied when no limit is provided
- The implementation matches the API contract defined in the OpenAPI specification

## Testing

All 13 congress tool unit tests pass successfully with these changes.

Fixes #120